### PR TITLE
Feat/expression

### DIFF
--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -327,6 +327,10 @@ def cast_to_user_defined_type(value, from_type, options):
     raise NotImplementedError("Pysparkling does not support yet cast to UDF")
 
 
+DESTINATION_DEPENDENT_CASTERS = {
+    DecimalType: cast_to_decimal,
+}
+
 CASTERS = {
     StringType: cast_to_string,
     BinaryType: cast_to_binary,

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -327,7 +327,9 @@ def cast_to_double(value, from_type, options):
 
 def cast_to_array(value, from_type, to_type, options):
     if isinstance(from_type, ArrayType):
-        caster = get_caster(from_type=from_type.elementType, to_type=to_type.elementType, options=options)
+        caster = get_caster(
+            from_type=from_type.elementType, to_type=to_type.elementType, options=options
+        )
         return [
             caster(sub_value) if sub_value is not None else None
             for sub_value in value
@@ -337,8 +339,12 @@ def cast_to_array(value, from_type, to_type, options):
 
 def cast_to_map(value, from_type, to_type, options):
     if isinstance(from_type, MapType):
-        key_caster = get_caster(from_type=from_type.keyType, to_type=to_type.keyType, options=options)
-        value_caster = get_caster(from_type=from_type.valueType, to_type=to_type.valueType, options=options)
+        key_caster = get_caster(
+            from_type=from_type.keyType, to_type=to_type.keyType, options=options
+        )
+        value_caster = get_caster(
+            from_type=from_type.valueType, to_type=to_type.valueType, options=options
+        )
         return {
             key_caster(key): (value_caster(sub_value) if sub_value is not None else None)
             for key, sub_value in value.items()
@@ -474,7 +480,7 @@ def get_sub_formatter(group):
     return lambda value: token
 
 
-@lru_cache
+@lru_cache(64)
 def get_time_formatter(java_time_format):
     """
     Convert a Java time format to a Python time format.
@@ -502,7 +508,7 @@ def get_unix_timestamp_parser(java_time_format):
     return time_parser
 
 
-@lru_cache
+@lru_cache(64)
 def get_datetime_parser(java_time_format):
     if java_time_format is None:
         return lambda value: cast_to_timestamp(value, StringType(), {})

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -226,6 +226,16 @@ def split_datetime_as_string(value):
     return date_as_string, time_as_string
 
 
+def cast_to_boolean(value, from_type, options):
+    if value == "" or value is None:
+        return None
+    if isinstance(from_type, StringType):
+        return True if value.lower() == "true" else False if value.lower() == "false" else None
+    if isinstance(from_type, (NumericType, BooleanType)):
+        return bool(value)
+    raise AnalysisException("Cannot cast type {0} to boolean".format(from_type))
+
+
 def cast_value(value, options):
     if value == "":
         return None

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -153,6 +153,23 @@ def split_datetime_as_string(value):
     return date_as_string, time_as_string
 
 
+def cast_value(value, options):
+    if value == "":
+        return None
+    if isinstance(value, datetime.datetime):
+        return value.timestamp()
+    if isinstance(value, datetime.date):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    raise ValueError("Unable to cast from value")
+
+
 def cast_to_user_defined_type(value, from_type, options):
     raise NotImplementedError("Pysparkling does not support yet cast to UDF")
 

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -51,6 +51,8 @@ def cast_to_string(value, from_type, options):
         return date_format(value)
     if isinstance(from_type, TimestampType):
         return timestamp_format(value)
+    if isinstance(from_type, (ArrayType, StructType, MapType)):
+        return cast_nested_to_str(value, from_type, options)
     if isinstance(from_type, BooleanType):
         return str(value).lower()
     return str(value)

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -62,3 +62,27 @@ FORMAT_MAPPING = {
     "DDD": "%j",
     "D": "%-j",
 }
+
+
+def get_sub_formatter(group):
+    token, _ = group
+
+    if token in FORMAT_MAPPING:
+        return lambda value: value.strftime(FORMAT_MAPPING[token])
+
+    if token in ("'", "[", "]"):
+        return lambda value: ""
+
+    if "S" in token:
+        number_of_digits = len(token)
+        return lambda value: value.strftime("%f")[:number_of_digits]
+
+    if token == "XXX":
+        def timezone_formatter(value):
+            tz = value.strftime("%z")
+            return "{0}{1}{2}:{3}{4}".format(*tz) if tz else ""
+
+        return timezone_formatter
+
+    return lambda value: token
+

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -324,6 +324,16 @@ def cast_to_double(value, from_type, options):
     return cast_to_float(value, from_type, options=options)
 
 
+def cast_to_array(value, from_type, to_type, options):
+    if isinstance(from_type, ArrayType):
+        caster = get_caster(from_type=from_type.elementType, to_type=to_type.elementType, options=options)
+        return [
+            caster(sub_value) if sub_value is not None else None
+            for sub_value in value
+        ]
+    raise AnalysisException("Cannot cast type {0} to array".format(from_type))
+
+
 def cast_to_user_defined_type(value, from_type, options):
     raise NotImplementedError("Pysparkling does not support yet cast to UDF")
 

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -266,6 +266,11 @@ def cast_to_int(value, from_type, options):
     return _cast_to_bounded_type("int", min_value, max_value, value, from_type, options=options)
 
 
+def cast_to_long(value, from_type, options):
+    min_value, max_value = -9223372036854775808, 9223372036854775807
+    return _cast_to_bounded_type("long", min_value, max_value, value, from_type, options=options)
+
+
 def cast_value(value, options):
     if value == "":
         return None

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -7,7 +7,7 @@ import pytz
 from dateutil.tz import tzlocal
 
 from pysparkling.sql.types import TimestampType, DateType, StringType, NumericType, BooleanType, BinaryType, StructType, \
-    ArrayType, MapType, FloatType
+    ArrayType, MapType, FloatType, ByteType, ShortType, IntegerType, LongType, DoubleType, UserDefinedType, DecimalType
 from pysparkling.sql.utils import AnalysisException
 
 NO_TIMESTAMP_CONVERSION = object()
@@ -325,6 +325,25 @@ def cast_to_double(value, from_type, options):
 
 def cast_to_user_defined_type(value, from_type, options):
     raise NotImplementedError("Pysparkling does not support yet cast to UDF")
+
+
+CASTERS = {
+    StringType: cast_to_string,
+    BinaryType: cast_to_binary,
+    DateType: cast_to_date,
+    TimestampType: cast_to_timestamp,
+    # The ticket to expose CalendarIntervalType, in pyspark is SPARK-28492
+    # It is open as this function is written, so we do not support it at the moment.
+    # CalendarIntervalType: cast_to_interval,
+    BooleanType: cast_to_boolean,
+    ByteType: cast_to_byte,
+    ShortType: cast_to_short,
+    IntegerType: cast_to_int,
+    FloatType: cast_to_float,
+    LongType: cast_to_long,
+    DoubleType: cast_to_double,
+    UserDefinedType: cast_to_user_defined_type,
+}
 
 
 FORMAT_MAPPING = {

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -1,14 +1,15 @@
 import datetime
 import re
 import time
-from functools import lru_cache, partial
+from functools import partial, lru_cache
 
 import pytz
 from dateutil.tz import tzlocal
 
-from pysparkling.sql.types import TimestampType, DateType, StringType, NumericType, BooleanType, BinaryType, StructType, \
-    ArrayType, MapType, FloatType, ByteType, ShortType, IntegerType, LongType, DoubleType, UserDefinedType, DecimalType, \
-    NullType, create_row
+from pysparkling.sql.types import UserDefinedType, NumericType, DateType, \
+    TimestampType, ArrayType, StructType, MapType, BooleanType, StringType, BinaryType, \
+    FloatType, ByteType, ShortType, IntegerType, LongType, DoubleType, NullType, \
+    DecimalType, create_row
 from pysparkling.sql.utils import AnalysisException
 
 NO_TIMESTAMP_CONVERSION = object()

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -345,6 +345,12 @@ def cast_to_map(value, from_type, to_type, options):
     raise AnalysisException("Cannot cast type {0} to map".format(from_type))
 
 
+def cast_to_struct(value, from_type, to_type, options):
+    if isinstance(from_type, StructType):
+        return get_struct_caster(from_type, to_type, options)(value)
+    raise NotImplementedError("Pysparkling does not support yet cast to struct")
+
+
 def get_struct_caster(from_type, to_type, options):
     names = [to_field.name for to_field in to_type.fields]
     casters = [

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -319,6 +319,10 @@ def cast_value(value, options):
     raise ValueError("Unable to cast from value")
 
 
+def cast_to_double(value, from_type, options):
+    return cast_to_float(value, from_type, options=options)
+
+
 def cast_to_user_defined_type(value, from_type, options):
     raise NotImplementedError("Pysparkling does not support yet cast to UDF")
 

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -256,6 +256,11 @@ def cast_to_byte(value, from_type, options):
     return _cast_to_bounded_type("byte", min_value, max_value, value, from_type, options=options)
 
 
+def cast_to_short(value, from_type, options):
+    min_value, max_value = -32768, 32767
+    return _cast_to_bounded_type("short", min_value, max_value, value, from_type, options=options)
+
+
 def cast_value(value, options):
     if value == "":
         return None

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -271,6 +271,17 @@ def cast_to_long(value, from_type, options):
     return _cast_to_bounded_type("long", min_value, max_value, value, from_type, options=options)
 
 
+def cast_to_float(value, from_type, options):
+    # NB: pysparkling does not mimic the loss of accuracy of Spark nor value
+    # bounding between float min&max values
+    try:
+        return cast_value(value, options=options)
+    except ValueError:
+        if isinstance(from_type, (DateType, TimestampType, NumericType, StringType)):
+            return None
+        raise AnalysisException("Cannot cast type {0} to float".format(from_type))
+
+
 def cast_value(value, options):
     if value == "":
         return None

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -251,6 +251,10 @@ def _cast_to_bounded_type(name, min_value, max_value, value, from_type, options)
     raise AnalysisException("Cannot cast type {0} to {1}".format(from_type, name))
 
 
+def cast_to_byte(value, from_type, options):
+    min_value, max_value = -128, 127
+    return _cast_to_bounded_type("byte", min_value, max_value, value, from_type, options=options)
+
 
 def cast_value(value, options):
     if value == "":

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -39,6 +39,21 @@ def default_timestamp_formatter(timestamp):
     return timestamp.strftime("%Y-%m-%d %H:%M:%S")
 
 
+def cast_to_string(value, from_type, options):
+    date_format = get_time_formatter(options.get("dateformat", "yyyy-MM-dd"))
+    timestamp_format = (get_time_formatter(options["timestampformat"])
+                        if "timestampformat" in options
+                        else default_timestamp_formatter)
+    if value is None:
+        return "null"
+    if isinstance(from_type, DateType):
+        return date_format(value)
+    if isinstance(from_type, TimestampType):
+        return timestamp_format(value)
+    if isinstance(from_type, BooleanType):
+        return str(value).lower()
+    return str(value)
+
 
 def cast_to_binary(value, from_type, options):
     if isinstance(from_type, StringType):

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -334,6 +334,17 @@ def cast_to_array(value, from_type, to_type, options):
     raise AnalysisException("Cannot cast type {0} to array".format(from_type))
 
 
+def cast_to_map(value, from_type, to_type, options):
+    if isinstance(from_type, MapType):
+        key_caster = get_caster(from_type=from_type.keyType, to_type=to_type.keyType, options=options)
+        value_caster = get_caster(from_type=from_type.valueType, to_type=to_type.valueType, options=options)
+        return {
+            key_caster(key): (value_caster(sub_value) if sub_value is not None else None)
+            for key, sub_value in value.items()
+        }
+    raise AnalysisException("Cannot cast type {0} to map".format(from_type))
+
+
 def cast_to_user_defined_type(value, from_type, options):
     raise NotImplementedError("Pysparkling does not support yet cast to UDF")
 

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -35,6 +35,11 @@ def cast_from_none(value, from_type, options):
     )
 
 
+def default_timestamp_formatter(timestamp):
+    return timestamp.strftime("%Y-%m-%d %H:%M:%S")
+
+
+
 def cast_to_binary(value, from_type, options):
     if isinstance(from_type, StringType):
         # noinspection PyTypeChecker

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -1,0 +1,16 @@
+import re
+import pytz
+
+NO_TIMESTAMP_CONVERSION = object()
+
+JAVA_TIME_FORMAT_TOKENS = re.compile("(([a-zA-Z])\\2*|[^a-zA-Z]+)")
+
+TIME_REGEX = re.compile(
+    "^([0-9]+):([0-9]+)?(?::([0-9]+))?(?:\\.([0-9]+))?(Z|[+-][0-9]+(?::(?:[0-9]+)?)?)?$"
+)
+
+GMT = pytz.timezone("GMT")
+
+
+def identity(value, options):
+    return value

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -229,6 +229,7 @@ def get_time_formatter(java_time_format):
     return time_formatter
 
 
+@lru_cache
 def get_datetime_parser(java_time_format):
     if java_time_format is None:
         return lambda value: cast_to_timestamp(value, StringType(), {})

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -153,6 +153,10 @@ def split_datetime_as_string(value):
     return date_as_string, time_as_string
 
 
+def cast_to_user_defined_type(value, from_type, options):
+    raise NotImplementedError("Pysparkling does not support yet cast to UDF")
+
+
 FORMAT_MAPPING = {
     "EEEE": "%A",
     "EEE": "%a",

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -1,5 +1,6 @@
 import re
 import pytz
+from pysparkling.sql.utils import AnalysisException
 
 NO_TIMESTAMP_CONVERSION = object()
 
@@ -14,3 +15,14 @@ GMT = pytz.timezone("GMT")
 
 def identity(value, options):
     return value
+
+
+def cast_from_none(value, from_type, options):
+    if value is None:
+        return None
+    raise AnalysisException(
+        "Expected a null value from a field with type {0}, got {1}".format(
+            from_type,
+            value
+        )
+    )

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -60,6 +60,29 @@ def cast_to_date(value, from_type, options):
     raise AnalysisException("Cannot cast type {0} to date".format(from_type))
 
 
+def parse_time_as_string(time_as_string):
+    time_as_string = time_as_string.strip()
+    match = TIME_REGEX.match(time_as_string)
+    if not match:
+        return None
+
+    hour, minute, second, microsecond, tz_as_string = match.groups()
+    if microsecond:
+        microsecond = microsecond[:6]  # mimic Spark behaviour
+
+    tzinfo = parse_timezone(tz_as_string)
+    if tzinfo is None:  # Unable to parse
+        return None
+
+    return dict(
+        hour=int(hour),
+        minute=int(minute) if minute else 0,
+        second=int(second) if second else 0,
+        microsecond=int(microsecond) if microsecond else 0,
+        tzinfo=tzinfo
+    )
+
+
 def parse_timezone(tz_as_string):
     if tz_as_string:
         if tz_as_string == "Z":

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -26,3 +26,39 @@ def cast_from_none(value, from_type, options):
             value
         )
     )
+
+
+FORMAT_MAPPING = {
+    "EEEE": "%A",
+    "EEE": "%a",
+    "EE": "%a",
+    "E": "%a",
+    "e": "%w",
+    "dd": "%d",
+    "d": "%-d",
+    "MMMM": "%B",
+    "MMM": "%b",
+    "MM": "%m",
+    "M": "%-m",
+    "yyyy": "%Y",
+    "yyy": "%Y",
+    "yy": "%y",
+    "y": "%Y",
+    "HH": "%H",
+    "H": "%-H",
+    "hh": "%I",
+    "h": "%-I",
+    "a": "%p",
+    "mm": "%M",
+    "m": "%-M",
+    "ss": "%S",
+    "s": "%-S",
+    "S": "%f",
+    "xxxx": "%z",
+    "xx": "%z",
+    "ZZZ": "%z",
+    "ZZ": "%z",
+    "Z": "%z",
+    "DDD": "%j",
+    "D": "%-j",
+}

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -374,6 +374,9 @@ def cast_to_user_defined_type(value, from_type, options):
 
 DESTINATION_DEPENDENT_CASTERS = {
     DecimalType: cast_to_decimal,
+    ArrayType: cast_to_array,
+    MapType: cast_to_map,
+    StructType: cast_to_struct,
 }
 
 CASTERS = {

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 import pytz
 from dateutil.tz import tzlocal
 
-from pysparkling.sql.types import TimestampType, DateType, StringType, NumericType, BooleanType
+from pysparkling.sql.types import TimestampType, DateType, StringType, NumericType, BooleanType, BinaryType
 from pysparkling.sql.utils import AnalysisException
 
 NO_TIMESTAMP_CONVERSION = object()
@@ -33,6 +33,15 @@ def cast_from_none(value, from_type, options):
             value
         )
     )
+
+
+def cast_to_binary(value, from_type, options):
+    if isinstance(from_type, StringType):
+        # noinspection PyTypeChecker
+        return bytearray(value, 'utf-8')
+    if isinstance(from_type, BinaryType):
+        return value
+    raise AnalysisException("Cannot cast type {0} to binary".format(from_type))
 
 
 def cast_to_date(value, from_type, options):

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -55,6 +55,21 @@ def cast_to_string(value, from_type, options):
     return str(value)
 
 
+def cast_map(value, from_type, options):
+    casted_values = [
+        (cast_to_string(key, from_type.keyType, options),
+         (cast_to_string(sub_value, from_type.valueType, options)
+          if sub_value is not None else None))
+        for key, sub_value in value.items()
+    ]
+    return "[{0}]".format(
+        ", ".join("{0} ->{1}".format(
+            casted_key,
+            " {0}".format(casted_value) if casted_value is not None else ""
+        ) for casted_key, casted_value in casted_values)
+    )
+
+
 def cast_sequence(value, from_type, options):
     if isinstance(from_type, StructType):
         types = [field.dataType for field in from_type.fields]

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -1,4 +1,6 @@
 import re
+from functools import lru_cache
+
 import pytz
 from pysparkling.sql.utils import AnalysisException
 
@@ -87,6 +89,7 @@ def get_sub_formatter(group):
     return lambda value: token
 
 
+@lru_cache
 def get_time_formatter(java_time_format):
     """
     Convert a Java time format to a Python time format.

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -271,6 +271,17 @@ def cast_to_long(value, from_type, options):
     return _cast_to_bounded_type("long", min_value, max_value, value, from_type, options=options)
 
 
+def cast_to_decimal(value, from_type, to_type, options):
+    value_as_float = cast_to_float(value, from_type, options=options)
+    if value_as_float is None:
+        return None
+    if value_as_float >= 10 ** (to_type.precision - to_type.scale):
+        return None
+    if to_type.scale == 0:
+        return int(value_as_float)
+    return round(value_as_float, ndigits=to_type.scale)
+
+
 def cast_to_float(value, from_type, options):
     # NB: pysparkling does not mimic the loss of accuracy of Spark nor value
     # bounding between float min&max values

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -7,7 +7,7 @@ import pytz
 from dateutil.tz import tzlocal
 
 from pysparkling.sql.types import TimestampType, DateType, StringType, NumericType, BooleanType, BinaryType, StructType, \
-    ArrayType, MapType
+    ArrayType, MapType, FloatType
 from pysparkling.sql.utils import AnalysisException
 
 NO_TIMESTAMP_CONVERSION = object()
@@ -242,6 +242,15 @@ def _cast_to_bounded_type(name, min_value, max_value, value, from_type, options)
     size = max_value - min_value + 1
     if isinstance(from_type, DateType):
         return None
+    if isinstance(from_type, TimestampType):
+        return _cast_to_bounded_type(
+            name,
+            min_value,
+            max_value,
+            cast_to_float(value, from_type, options=options),
+            FloatType(),
+            options=options
+        )
     if isinstance(from_type, StringType):
         casted_value = int(value)
         return casted_value if min_value <= casted_value <= max_value else None

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -261,6 +261,11 @@ def cast_to_short(value, from_type, options):
     return _cast_to_bounded_type("short", min_value, max_value, value, from_type, options=options)
 
 
+def cast_to_int(value, from_type, options):
+    min_value, max_value = -2147483648, 2147483647
+    return _cast_to_bounded_type("int", min_value, max_value, value, from_type, options=options)
+
+
 def cast_value(value, options):
     if value == "":
         return None

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -227,3 +227,16 @@ def get_time_formatter(java_time_format):
         return "".join(sub_formatter(value) for sub_formatter in sub_formatters)
 
     return time_formatter
+
+
+def get_datetime_parser(java_time_format):
+    if java_time_format is None:
+        return lambda value: cast_to_timestamp(value, StringType(), {})
+
+    if java_time_format is NO_TIMESTAMP_CONVERSION:
+        return lambda value: None
+
+    python_pattern = ""
+    for token, _ in JAVA_TIME_FORMAT_TOKENS.findall(java_time_format):
+        python_pattern += FORMAT_MAPPING.get(token, token)
+    return lambda value: datetime.datetime.strptime(value, python_pattern)

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 from functools import lru_cache
 
@@ -28,6 +29,22 @@ def cast_from_none(value, from_type, options):
             value
         )
     )
+
+
+def split_datetime_as_string(value):
+    first_space_position = (value.find(' ') + 1) or len(value)
+    first_t_position = (value.find('T') + 1) or len(value)
+    if first_space_position == len(value) and first_t_position == len(value):
+        if ":" in value:
+            # Value is only a time
+            return datetime.date.today().strftime("%Y-%m-%d"), value
+        # Value is only a date
+        return value, "00:00:00"
+    # Value is a datetime
+    separation = min(first_space_position, first_t_position)
+    date_as_string = value[:separation]
+    time_as_string = value[separation:]
+    return date_as_string, time_as_string
 
 
 FORMAT_MAPPING = {

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -86,3 +86,19 @@ def get_sub_formatter(group):
 
     return lambda value: token
 
+
+def get_time_formatter(java_time_format):
+    """
+    Convert a Java time format to a Python time format.
+
+    This function currently only support a small subset of Java time formats.
+    """
+    sub_formatters = [
+        get_sub_formatter(token)
+        for token in JAVA_TIME_FORMAT_TOKENS.findall(java_time_format)
+    ]
+
+    def time_formatter(value):
+        return "".join(sub_formatter(value) for sub_formatter in sub_formatters)
+
+    return time_formatter

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -6,7 +6,8 @@ from functools import lru_cache
 import pytz
 from dateutil.tz import tzlocal
 
-from pysparkling.sql.types import TimestampType, DateType, StringType, NumericType, BooleanType, BinaryType, StructType
+from pysparkling.sql.types import TimestampType, DateType, StringType, NumericType, BooleanType, BinaryType, StructType, \
+    ArrayType, MapType
 from pysparkling.sql.utils import AnalysisException
 
 NO_TIMESTAMP_CONVERSION = object()
@@ -53,6 +54,14 @@ def cast_to_string(value, from_type, options):
     if isinstance(from_type, BooleanType):
         return str(value).lower()
     return str(value)
+
+
+def cast_nested_to_str(value, from_type, options):
+    if isinstance(from_type, (ArrayType, StructType)):
+        return cast_sequence(value, from_type, options)
+    if isinstance(from_type, MapType):
+        return cast_map(value, from_type, options)
+    raise TypeError("Unable to cast {0}".format(type(from_type)))
 
 
 def cast_map(value, from_type, options):

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+import time
 from functools import lru_cache
 
 import pytz
@@ -227,6 +228,16 @@ def get_time_formatter(java_time_format):
         return "".join(sub_formatter(value) for sub_formatter in sub_formatters)
 
     return time_formatter
+
+
+def get_unix_timestamp_parser(java_time_format):
+    datetime_parser = get_datetime_parser(java_time_format)
+
+    def time_parser(value):
+        dt = datetime_parser(value)
+        return int(time.mktime(dt.timetuple()))
+
+    return time_parser
 
 
 @lru_cache

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -236,6 +236,22 @@ def cast_to_boolean(value, from_type, options):
     raise AnalysisException("Cannot cast type {0} to boolean".format(from_type))
 
 
+def _cast_to_bounded_type(name, min_value, max_value, value, from_type, options):
+    if value == "" or value is None:
+        return None
+    size = max_value - min_value + 1
+    if isinstance(from_type, DateType):
+        return None
+    if isinstance(from_type, StringType):
+        casted_value = int(value)
+        return casted_value if min_value <= casted_value <= max_value else None
+    if isinstance(from_type, (NumericType, BooleanType)):
+        value = int(value)
+        return value % size if value % size <= max_value else value % -size
+    raise AnalysisException("Cannot cast type {0} to {1}".format(from_type, name))
+
+
+
 def cast_value(value, options):
     if value == "":
         return None

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -43,3 +43,20 @@ class Expression(object):
     @property
     def is_an_aggregation(self):
         return False
+
+    def merge(self, row, schema):
+        pass
+
+    def recursive_merge(self, row, schema):
+        self.merge(row, schema)
+        self.children_merge(self.children, row, schema)
+
+    @staticmethod
+    def children_merge(children, row, schema):
+        for child in children:
+            if isinstance(child, Expression):
+                child.recursive_merge(row, schema)
+            elif hasattr(child, "expr") and isinstance(child.expr, Expression):
+                child.expr.recursive_merge(row, schema)
+            elif isinstance(child, (list, set, tuple)):
+                Expression.children_merge(child, row, schema)

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -60,3 +60,31 @@ class Expression(object):
                 child.expr.recursive_merge(row, schema)
             elif isinstance(child, (list, set, tuple)):
                 Expression.children_merge(child, row, schema)
+
+    def mergeStats(self, other, schema):
+        pass
+
+    def recursive_merge_stats(self, other, schema):
+        # todo: Add logic
+        # # Top level import would cause cyclic dependencies
+        # # pylint: disable=import-outside-toplevel
+        # from pysparkling.sql.expressions.operators import Alias
+        # if isinstance(other.expr, Alias):
+        #     self.recursive_merge_stats(other.expr.expr, schema)
+        # else:
+        self.mergeStats(other.expr, schema)
+        self.children_merge_stats(self.children, other, schema)
+
+    @staticmethod
+    def children_merge_stats(children, other, schema):
+        # # Top level import would cause cyclic dependencies
+        # # pylint: disable=import-outside-toplevel
+        # from pysparkling.sql.column import Column
+        for child in children:
+            if isinstance(child, Expression):
+                child.recursive_merge_stats(other, schema)
+            # todo: elif isinstance(child, Column) and isinstance(child.expr, Expression):
+            elif isinstance(child.expr, Expression):
+                child.expr.recursive_merge_stats(other, schema)
+            elif isinstance(child, (list, set, tuple)):
+                Expression.children_merge_stats(child, other, schema)

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -35,3 +35,7 @@ class Expression(object):
     @property
     def may_output_multiple_cols(self):
         return False
+
+    @property
+    def may_output_multiple_rows(self):
+        return False

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -248,3 +248,18 @@ class NullSafeBinaryOperation(BinaryOperation):
     def unsafe_operation(self, value1, value2):
         raise NotImplementedError
 
+
+class NullSafeColumnOperation(Expression):
+    def __init__(self, column, *args):
+        super(NullSafeColumnOperation, self).__init__(column, *args)
+        self.column = column
+
+    def eval(self, row, schema):
+        value = self.column.eval(row, schema)
+        return self.unsafe_operation(value)
+
+    def __str__(self):
+        raise NotImplementedError
+
+    def unsafe_operation(self, value):
+        raise NotImplementedError

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -1,0 +1,33 @@
+from pysparkling.sql.types import StructField, DataType
+
+
+class Expression(object):
+    def __init__(self, *children):
+        self.children = children
+        self.pre_evaluation_schema = None
+
+    def eval(self, row, schema):
+        raise NotImplementedError
+
+    def __str__(self):
+        raise NotImplementedError
+
+    def __repr__(self):
+        return self.__class__.__name__
+
+    def output_fields(self, schema):
+        return [StructField(
+            name=str(self),
+            dataType=self.data_type,
+            nullable=self.is_nullable
+        )]
+
+    @property
+    def data_type(self):
+        # pylint: disable=W0511
+        # todo: be more specific
+        return DataType()
+
+    @property
+    def is_nullable(self):
+        return True

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -39,3 +39,7 @@ class Expression(object):
     @property
     def may_output_multiple_rows(self):
         return False
+
+    @property
+    def is_an_aggregation(self):
+        return False

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -148,3 +148,20 @@ class UnaryExpression(Expression):
 
     def __str__(self):
         raise NotImplementedError
+
+
+class BinaryOperation(Expression):
+    """
+    Perform a binary operation but return None if any value is None
+    """
+
+    def __init__(self, arg1, arg2):
+        super(BinaryOperation, self).__init__(arg1, arg2)
+        self.arg1 = arg1
+        self.arg2 = arg2
+
+    def eval(self, row, schema):
+        raise NotImplementedError
+
+    def __str__(self):
+        raise NotImplementedError

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -136,3 +136,15 @@ class Expression(object):
                 child.expr.recursive_pre_evaluation_schema(schema)
             elif isinstance(child, (list, set, tuple)):
                 Expression.children_pre_evaluation_schema(child, schema)
+
+
+class UnaryExpression(Expression):
+    def __init__(self, column):
+        super(UnaryExpression, self).__init__(column)
+        self.column = column
+
+    def eval(self, row, schema):
+        raise NotImplementedError
+
+    def __str__(self):
+        raise NotImplementedError

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -31,3 +31,7 @@ class Expression(object):
     @property
     def is_nullable(self):
         return True
+
+    @property
+    def may_output_multiple_cols(self):
+        return False


### PR DESCRIPTION
File modified in this PR:
- new: [pysparkling/sql/expressions/expressions.py](https://github.com/svenkreiss/pysparkling/pull/109/files#diff-b6e5bf163e8127e1dd4425a458a60082)


`df.age == 10` is represented by Spark as a `Column` which contains an `Expression`.

In this particular case it's an Equal Expression with two children: `df.age` which refers to the `Column` `age` of `df` rows and the `Literal` `10`.

Those `Expression`s can be more complex and are also used for aggregations.

This PR introduces several abstract classes from which Expression will inherit.

This PR is on top of #108