### PR TITLE
Feat/orders

### DIFF
--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -327,6 +327,10 @@ def cast_to_user_defined_type(value, from_type, options):
     raise NotImplementedError("Pysparkling does not support yet cast to UDF")
 
 
+DESTINATION_DEPENDENT_CASTERS = {
+    DecimalType: cast_to_decimal,
+}
+
 CASTERS = {
     StringType: cast_to_string,
     BinaryType: cast_to_binary,

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -327,7 +327,9 @@ def cast_to_double(value, from_type, options):
 
 def cast_to_array(value, from_type, to_type, options):
     if isinstance(from_type, ArrayType):
-        caster = get_caster(from_type=from_type.elementType, to_type=to_type.elementType, options=options)
+        caster = get_caster(
+            from_type=from_type.elementType, to_type=to_type.elementType, options=options
+        )
         return [
             caster(sub_value) if sub_value is not None else None
             for sub_value in value
@@ -337,8 +339,12 @@ def cast_to_array(value, from_type, to_type, options):
 
 def cast_to_map(value, from_type, to_type, options):
     if isinstance(from_type, MapType):
-        key_caster = get_caster(from_type=from_type.keyType, to_type=to_type.keyType, options=options)
-        value_caster = get_caster(from_type=from_type.valueType, to_type=to_type.valueType, options=options)
+        key_caster = get_caster(
+            from_type=from_type.keyType, to_type=to_type.keyType, options=options
+        )
+        value_caster = get_caster(
+            from_type=from_type.valueType, to_type=to_type.valueType, options=options
+        )
         return {
             key_caster(key): (value_caster(sub_value) if sub_value is not None else None)
             for key, sub_value in value.items()
@@ -474,7 +480,7 @@ def get_sub_formatter(group):
     return lambda value: token
 
 
-@lru_cache
+@lru_cache(64)
 def get_time_formatter(java_time_format):
     """
     Convert a Java time format to a Python time format.
@@ -502,7 +508,7 @@ def get_unix_timestamp_parser(java_time_format):
     return time_parser
 
 
-@lru_cache
+@lru_cache(64)
 def get_datetime_parser(java_time_format):
     if java_time_format is None:
         return lambda value: cast_to_timestamp(value, StringType(), {})

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -324,6 +324,16 @@ def cast_to_double(value, from_type, options):
     return cast_to_float(value, from_type, options=options)
 
 
+def cast_to_array(value, from_type, to_type, options):
+    if isinstance(from_type, ArrayType):
+        caster = get_caster(from_type=from_type.elementType, to_type=to_type.elementType, options=options)
+        return [
+            caster(sub_value) if sub_value is not None else None
+            for sub_value in value
+        ]
+    raise AnalysisException("Cannot cast type {0} to array".format(from_type))
+
+
 def cast_to_user_defined_type(value, from_type, options):
     raise NotImplementedError("Pysparkling does not support yet cast to UDF")
 

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -266,6 +266,11 @@ def cast_to_int(value, from_type, options):
     return _cast_to_bounded_type("int", min_value, max_value, value, from_type, options=options)
 
 
+def cast_to_long(value, from_type, options):
+    min_value, max_value = -9223372036854775808, 9223372036854775807
+    return _cast_to_bounded_type("long", min_value, max_value, value, from_type, options=options)
+
+
 def cast_value(value, options):
     if value == "":
         return None

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -7,7 +7,7 @@ import pytz
 from dateutil.tz import tzlocal
 
 from pysparkling.sql.types import TimestampType, DateType, StringType, NumericType, BooleanType, BinaryType, StructType, \
-    ArrayType, MapType, FloatType
+    ArrayType, MapType, FloatType, ByteType, ShortType, IntegerType, LongType, DoubleType, UserDefinedType, DecimalType
 from pysparkling.sql.utils import AnalysisException
 
 NO_TIMESTAMP_CONVERSION = object()
@@ -325,6 +325,25 @@ def cast_to_double(value, from_type, options):
 
 def cast_to_user_defined_type(value, from_type, options):
     raise NotImplementedError("Pysparkling does not support yet cast to UDF")
+
+
+CASTERS = {
+    StringType: cast_to_string,
+    BinaryType: cast_to_binary,
+    DateType: cast_to_date,
+    TimestampType: cast_to_timestamp,
+    # The ticket to expose CalendarIntervalType, in pyspark is SPARK-28492
+    # It is open as this function is written, so we do not support it at the moment.
+    # CalendarIntervalType: cast_to_interval,
+    BooleanType: cast_to_boolean,
+    ByteType: cast_to_byte,
+    ShortType: cast_to_short,
+    IntegerType: cast_to_int,
+    FloatType: cast_to_float,
+    LongType: cast_to_long,
+    DoubleType: cast_to_double,
+    UserDefinedType: cast_to_user_defined_type,
+}
 
 
 FORMAT_MAPPING = {

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -1,14 +1,15 @@
 import datetime
 import re
 import time
-from functools import lru_cache, partial
+from functools import partial, lru_cache
 
 import pytz
 from dateutil.tz import tzlocal
 
-from pysparkling.sql.types import TimestampType, DateType, StringType, NumericType, BooleanType, BinaryType, StructType, \
-    ArrayType, MapType, FloatType, ByteType, ShortType, IntegerType, LongType, DoubleType, UserDefinedType, DecimalType, \
-    NullType, create_row
+from pysparkling.sql.types import UserDefinedType, NumericType, DateType, \
+    TimestampType, ArrayType, StructType, MapType, BooleanType, StringType, BinaryType, \
+    FloatType, ByteType, ShortType, IntegerType, LongType, DoubleType, NullType, \
+    DecimalType, create_row
 from pysparkling.sql.utils import AnalysisException
 
 NO_TIMESTAMP_CONVERSION = object()

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -345,6 +345,12 @@ def cast_to_map(value, from_type, to_type, options):
     raise AnalysisException("Cannot cast type {0} to map".format(from_type))
 
 
+def cast_to_struct(value, from_type, to_type, options):
+    if isinstance(from_type, StructType):
+        return get_struct_caster(from_type, to_type, options)(value)
+    raise NotImplementedError("Pysparkling does not support yet cast to struct")
+
+
 def get_struct_caster(from_type, to_type, options):
     names = [to_field.name for to_field in to_type.fields]
     casters = [

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -319,6 +319,10 @@ def cast_value(value, options):
     raise ValueError("Unable to cast from value")
 
 
+def cast_to_double(value, from_type, options):
+    return cast_to_float(value, from_type, options=options)
+
+
 def cast_to_user_defined_type(value, from_type, options):
     raise NotImplementedError("Pysparkling does not support yet cast to UDF")
 

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -256,6 +256,11 @@ def cast_to_byte(value, from_type, options):
     return _cast_to_bounded_type("byte", min_value, max_value, value, from_type, options=options)
 
 
+def cast_to_short(value, from_type, options):
+    min_value, max_value = -32768, 32767
+    return _cast_to_bounded_type("short", min_value, max_value, value, from_type, options=options)
+
+
 def cast_value(value, options):
     if value == "":
         return None

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -271,6 +271,17 @@ def cast_to_long(value, from_type, options):
     return _cast_to_bounded_type("long", min_value, max_value, value, from_type, options=options)
 
 
+def cast_to_float(value, from_type, options):
+    # NB: pysparkling does not mimic the loss of accuracy of Spark nor value
+    # bounding between float min&max values
+    try:
+        return cast_value(value, options=options)
+    except ValueError:
+        if isinstance(from_type, (DateType, TimestampType, NumericType, StringType)):
+            return None
+        raise AnalysisException("Cannot cast type {0} to float".format(from_type))
+
+
 def cast_value(value, options):
     if value == "":
         return None

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -334,6 +334,17 @@ def cast_to_array(value, from_type, to_type, options):
     raise AnalysisException("Cannot cast type {0} to array".format(from_type))
 
 
+def cast_to_map(value, from_type, to_type, options):
+    if isinstance(from_type, MapType):
+        key_caster = get_caster(from_type=from_type.keyType, to_type=to_type.keyType, options=options)
+        value_caster = get_caster(from_type=from_type.valueType, to_type=to_type.valueType, options=options)
+        return {
+            key_caster(key): (value_caster(sub_value) if sub_value is not None else None)
+            for key, sub_value in value.items()
+        }
+    raise AnalysisException("Cannot cast type {0} to map".format(from_type))
+
+
 def cast_to_user_defined_type(value, from_type, options):
     raise NotImplementedError("Pysparkling does not support yet cast to UDF")
 

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -374,6 +374,9 @@ def cast_to_user_defined_type(value, from_type, options):
 
 DESTINATION_DEPENDENT_CASTERS = {
     DecimalType: cast_to_decimal,
+    ArrayType: cast_to_array,
+    MapType: cast_to_map,
+    StructType: cast_to_struct,
 }
 
 CASTERS = {

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -271,6 +271,17 @@ def cast_to_long(value, from_type, options):
     return _cast_to_bounded_type("long", min_value, max_value, value, from_type, options=options)
 
 
+def cast_to_decimal(value, from_type, to_type, options):
+    value_as_float = cast_to_float(value, from_type, options=options)
+    if value_as_float is None:
+        return None
+    if value_as_float >= 10 ** (to_type.precision - to_type.scale):
+        return None
+    if to_type.scale == 0:
+        return int(value_as_float)
+    return round(value_as_float, ndigits=to_type.scale)
+
+
 def cast_to_float(value, from_type, options):
     # NB: pysparkling does not mimic the loss of accuracy of Spark nor value
     # bounding between float min&max values

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -7,7 +7,7 @@ import pytz
 from dateutil.tz import tzlocal
 
 from pysparkling.sql.types import TimestampType, DateType, StringType, NumericType, BooleanType, BinaryType, StructType, \
-    ArrayType, MapType
+    ArrayType, MapType, FloatType
 from pysparkling.sql.utils import AnalysisException
 
 NO_TIMESTAMP_CONVERSION = object()
@@ -242,6 +242,15 @@ def _cast_to_bounded_type(name, min_value, max_value, value, from_type, options)
     size = max_value - min_value + 1
     if isinstance(from_type, DateType):
         return None
+    if isinstance(from_type, TimestampType):
+        return _cast_to_bounded_type(
+            name,
+            min_value,
+            max_value,
+            cast_to_float(value, from_type, options=options),
+            FloatType(),
+            options=options
+        )
     if isinstance(from_type, StringType):
         casted_value = int(value)
         return casted_value if min_value <= casted_value <= max_value else None

--- a/pysparkling/sql/casts.py
+++ b/pysparkling/sql/casts.py
@@ -261,6 +261,11 @@ def cast_to_short(value, from_type, options):
     return _cast_to_bounded_type("short", min_value, max_value, value, from_type, options=options)
 
 
+def cast_to_int(value, from_type, options):
+    min_value, max_value = -2147483648, 2147483647
+    return _cast_to_bounded_type("int", min_value, max_value, value, from_type, options=options)
+
+
 def cast_value(value, options):
     if value == "":
         return None

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -43,3 +43,20 @@ class Expression(object):
     @property
     def is_an_aggregation(self):
         return False
+
+    def merge(self, row, schema):
+        pass
+
+    def recursive_merge(self, row, schema):
+        self.merge(row, schema)
+        self.children_merge(self.children, row, schema)
+
+    @staticmethod
+    def children_merge(children, row, schema):
+        for child in children:
+            if isinstance(child, Expression):
+                child.recursive_merge(row, schema)
+            elif hasattr(child, "expr") and isinstance(child.expr, Expression):
+                child.expr.recursive_merge(row, schema)
+            elif isinstance(child, (list, set, tuple)):
+                Expression.children_merge(child, row, schema)

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -60,3 +60,31 @@ class Expression(object):
                 child.expr.recursive_merge(row, schema)
             elif isinstance(child, (list, set, tuple)):
                 Expression.children_merge(child, row, schema)
+
+    def mergeStats(self, other, schema):
+        pass
+
+    def recursive_merge_stats(self, other, schema):
+        # todo: Add logic
+        # # Top level import would cause cyclic dependencies
+        # # pylint: disable=import-outside-toplevel
+        # from pysparkling.sql.expressions.operators import Alias
+        # if isinstance(other.expr, Alias):
+        #     self.recursive_merge_stats(other.expr.expr, schema)
+        # else:
+        self.mergeStats(other.expr, schema)
+        self.children_merge_stats(self.children, other, schema)
+
+    @staticmethod
+    def children_merge_stats(children, other, schema):
+        # # Top level import would cause cyclic dependencies
+        # # pylint: disable=import-outside-toplevel
+        # from pysparkling.sql.column import Column
+        for child in children:
+            if isinstance(child, Expression):
+                child.recursive_merge_stats(other, schema)
+            # todo: elif isinstance(child, Column) and isinstance(child.expr, Expression):
+            elif isinstance(child.expr, Expression):
+                child.expr.recursive_merge_stats(other, schema)
+            elif isinstance(child, (list, set, tuple)):
+                Expression.children_merge_stats(child, other, schema)

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -35,3 +35,7 @@ class Expression(object):
     @property
     def may_output_multiple_cols(self):
         return False
+
+    @property
+    def may_output_multiple_rows(self):
+        return False

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -248,3 +248,18 @@ class NullSafeBinaryOperation(BinaryOperation):
     def unsafe_operation(self, value1, value2):
         raise NotImplementedError
 
+
+class NullSafeColumnOperation(Expression):
+    def __init__(self, column, *args):
+        super(NullSafeColumnOperation, self).__init__(column, *args)
+        self.column = column
+
+    def eval(self, row, schema):
+        value = self.column.eval(row, schema)
+        return self.unsafe_operation(value)
+
+    def __str__(self):
+        raise NotImplementedError
+
+    def unsafe_operation(self, value):
+        raise NotImplementedError

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -1,0 +1,33 @@
+from pysparkling.sql.types import StructField, DataType
+
+
+class Expression(object):
+    def __init__(self, *children):
+        self.children = children
+        self.pre_evaluation_schema = None
+
+    def eval(self, row, schema):
+        raise NotImplementedError
+
+    def __str__(self):
+        raise NotImplementedError
+
+    def __repr__(self):
+        return self.__class__.__name__
+
+    def output_fields(self, schema):
+        return [StructField(
+            name=str(self),
+            dataType=self.data_type,
+            nullable=self.is_nullable
+        )]
+
+    @property
+    def data_type(self):
+        # pylint: disable=W0511
+        # todo: be more specific
+        return DataType()
+
+    @property
+    def is_nullable(self):
+        return True

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -39,3 +39,7 @@ class Expression(object):
     @property
     def may_output_multiple_rows(self):
         return False
+
+    @property
+    def is_an_aggregation(self):
+        return False

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -148,3 +148,20 @@ class UnaryExpression(Expression):
 
     def __str__(self):
         raise NotImplementedError
+
+
+class BinaryOperation(Expression):
+    """
+    Perform a binary operation but return None if any value is None
+    """
+
+    def __init__(self, arg1, arg2):
+        super(BinaryOperation, self).__init__(arg1, arg2)
+        self.arg1 = arg1
+        self.arg2 = arg2
+
+    def eval(self, row, schema):
+        raise NotImplementedError
+
+    def __str__(self):
+        raise NotImplementedError

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -136,3 +136,15 @@ class Expression(object):
                 child.expr.recursive_pre_evaluation_schema(schema)
             elif isinstance(child, (list, set, tuple)):
                 Expression.children_pre_evaluation_schema(child, schema)
+
+
+class UnaryExpression(Expression):
+    def __init__(self, column):
+        super(UnaryExpression, self).__init__(column)
+        self.column = column
+
+    def eval(self, row, schema):
+        raise NotImplementedError
+
+    def __str__(self):
+        raise NotImplementedError

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -31,3 +31,7 @@ class Expression(object):
     @property
     def is_nullable(self):
         return True
+
+    @property
+    def may_output_multiple_cols(self):
+        return False

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -120,3 +120,14 @@ class Or(TypeSafeBinaryOperation):
 
     def __str__(self):
         return "({0} OR {1})".format(self.arg1, self.arg2)
+
+
+class Invert(UnaryExpression):
+    def eval(self, row, schema):
+        value = self.column.eval(row, schema)
+        if value is None:
+            return None
+        return not value
+
+    def __str__(self):
+        return "(NOT {0})".format(self.column)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -300,3 +300,17 @@ class Cast(Expression):
 
     def __str__(self):
         return "{0}".format(self.column)
+
+
+class Substring(Expression):
+    def __init__(self, expr, start, length):
+        super(Substring, self).__init__(expr)
+        self.expr = expr
+        self.start = start
+        self.length = length
+
+    def eval(self, row, schema):
+        return str(self.expr.eval(row, schema))[self.start - 1:self.start - 1 + self.length]
+
+    def __str__(self):
+        return "substring({0}, {1}, {2})".format(self.expr, self.start, self.length)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -178,3 +178,17 @@ class BitwiseNot(UnaryExpression):
 
     def __str__(self):
         return "~{0}".format(self.column)
+
+
+class EqNullSafe(Expression):
+    def __init__(self, arg1, arg2):
+        super(EqNullSafe, self).__init__(arg1, arg2)
+        self.arg1 = arg1
+        self.arg2 = arg2
+
+    def eval(self, row, schema):
+        return self.arg1.eval(row, schema) == self.arg2.eval(row, schema)
+
+    def __str__(self):
+        return "({0} <=> {1})".format(self.arg1, self.arg2)
+

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -72,3 +72,11 @@ class Equal(TypeSafeBinaryOperation):
 
     def __str__(self):
         return "({0} = {1})".format(self.arg1, self.arg2)
+
+
+class LessThan(TypeSafeBinaryOperation):
+    def unsafe_operation(self, value_1, value_2):
+        return value_1 < value_2
+
+    def __str__(self):
+        return "({0} < {1})".format(self.arg1, self.arg2)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -49,3 +49,11 @@ class Mod(NullSafeBinaryOperation):
     def __str__(self):
         return "({0} % {1})".format(self.arg1, self.arg2)
 
+
+class Pow(NullSafeBinaryOperation):
+    def unsafe_operation(self, value1, value2):
+        return float(value1 ** value2)
+
+    def __str__(self):
+        return "POWER({0}, {1})".format(self.arg1, self.arg2)
+

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -1,4 +1,5 @@
-from pysparkling.sql.expressions.expressions import Expression, UnaryExpression
+from pysparkling.sql.expressions.expressions import Expression, UnaryExpression, \
+    NullSafeBinaryOperation
 
 
 class Negate(UnaryExpression):
@@ -7,3 +8,11 @@ class Negate(UnaryExpression):
 
     def __str__(self):
         return "(- {0})".format(self.column)
+
+
+class Add(NullSafeBinaryOperation):
+    def unsafe_operation(self, value1, value2):
+        return value1 + value2
+
+    def __str__(self):
+        return "({0} + {1})".format(self.arg1, self.arg2)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -1,4 +1,5 @@
 from pysparkling import Row
+from pysparkling.sql.casts import get_caster
 from pysparkling.sql.expressions.expressions import Expression, UnaryExpression, \
     NullSafeBinaryOperation, TypeSafeBinaryOperation
 
@@ -283,3 +284,19 @@ class IsNotNull(UnaryExpression):
 
     def __str__(self):
         return "({0} IS NOT NULL)".format(self.column)
+
+
+class Cast(Expression):
+    def __init__(self, column, destination_type):
+        super(Cast, self).__init__(column)
+        self.column = column
+        self.destination_type = destination_type
+        self.caster = get_caster(
+            from_type=self.column.data_type, to_type=destination_type, options={}
+        )
+
+    def eval(self, row, schema):
+        return self.caster(self.column.eval(row, schema))
+
+    def __str__(self):
+        return "{0}".format(self.column)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -40,3 +40,12 @@ class Divide(NullSafeBinaryOperation):
 
     def __str__(self):
         return "({0} / {1})".format(self.arg1, self.arg2)
+
+
+class Mod(NullSafeBinaryOperation):
+    def unsafe_operation(self, value1, value2):
+        return value1 % value2
+
+    def __str__(self):
+        return "({0} % {1})".format(self.arg1, self.arg2)
+

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -158,3 +158,15 @@ class BitwiseAnd(Expression):
     def __str__(self):
         return "({0} & {1})".format(self.arg1, self.arg2)
 
+
+class BitwiseXor(Expression):
+    def __init__(self, arg1, arg2):
+        super(BitwiseXor, self).__init__(arg1, arg2)
+        self.arg1 = arg1
+        self.arg2 = arg2
+
+    def eval(self, row, schema):
+        return self.arg1.eval(row, schema) ^ self.arg2.eval(row, schema)
+
+    def __str__(self):
+        return "({0} ^ {1})".format(self.arg1, self.arg2)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -259,3 +259,20 @@ class EndsWith(Expression):
 
     def __str__(self):
         return "endswith({0}, {1})".format(self.arg1, self.substr)
+
+
+class IsIn(Expression):
+    def __init__(self, arg1, cols):
+        super(IsIn, self).__init__(arg1)
+        self.arg1 = arg1
+        self.cols = cols
+
+    def eval(self, row, schema):
+        return self.arg1.eval(row, schema) in self.cols
+
+    def __str__(self):
+        return "({0} IN ({1}))".format(
+            self.arg1,
+            ", ".join(str(col) for col in self.cols)
+        )
+

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -276,3 +276,10 @@ class IsIn(Expression):
             ", ".join(str(col) for col in self.cols)
         )
 
+
+class IsNotNull(UnaryExpression):
+    def eval(self, row, schema):
+        return self.column.eval(row, schema) is not None
+
+    def __str__(self):
+        return "({0} IS NOT NULL)".format(self.column)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -233,3 +233,16 @@ class Contains(Expression):
 
     def __str__(self):
         return "contains({0}, {1})".format(self.expr, self.value)
+
+
+class StartsWith(Expression):
+    def __init__(self, arg1, substr):
+        super(StartsWith, self).__init__(arg1, substr)
+        self.arg1 = arg1
+        self.substr = substr
+
+    def eval(self, row, schema):
+        return str(self.arg1.eval(row, schema)).startswith(self.substr)
+
+    def __str__(self):
+        return "startswith({0}, {1})".format(self.arg1, self.substr)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -221,3 +221,15 @@ class GetField(Expression):
             return "{0}.{1}".format(self.item, self.field)
         return "{0}[{1}]".format(self.item, self.field)
 
+
+class Contains(Expression):
+    def __init__(self, expr, value):
+        super(Contains, self).__init__(expr, value)
+        self.expr = expr
+        self.value = value
+
+    def eval(self, row, schema):
+        return self.value.eval(row, schema) in self.expr.eval(row, schema)
+
+    def __str__(self):
+        return "contains({0}, {1})".format(self.expr, self.value)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -1,5 +1,5 @@
 from pysparkling.sql.expressions.expressions import Expression, UnaryExpression, \
-    NullSafeBinaryOperation
+    NullSafeBinaryOperation, TypeSafeBinaryOperation
 
 
 class Negate(UnaryExpression):
@@ -65,3 +65,10 @@ class Pmod(NullSafeBinaryOperation):
     def __str__(self):
         return "pmod({0} % {1})".format(self.arg1, self.arg2)
 
+
+class Equal(TypeSafeBinaryOperation):
+    def unsafe_operation(self, value_1, value_2):
+        return value_1 == value_2
+
+    def __str__(self):
+        return "({0} = {1})".format(self.arg1, self.arg2)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -170,3 +170,11 @@ class BitwiseXor(Expression):
 
     def __str__(self):
         return "({0} ^ {1})".format(self.arg1, self.arg2)
+
+
+class BitwiseNot(UnaryExpression):
+    def eval(self, row, schema):
+        return ~(self.column.eval(row, schema))
+
+    def __str__(self):
+        return "~{0}".format(self.column)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -1,0 +1,9 @@
+from pysparkling.sql.expressions.expressions import Expression, UnaryExpression
+
+
+class Negate(UnaryExpression):
+    def eval(self, row, schema):
+        return not self.column.eval(row, schema)
+
+    def __str__(self):
+        return "(- {0})".format(self.column)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -131,3 +131,16 @@ class Invert(UnaryExpression):
 
     def __str__(self):
         return "(NOT {0})".format(self.column)
+
+
+class BitwiseOr(Expression):
+    def __init__(self, arg1, arg2):
+        super(BitwiseOr, self).__init__(arg1, arg2)
+        self.arg1 = arg1
+        self.arg2 = arg2
+
+    def eval(self, row, schema):
+        return self.arg1.eval(row, schema) | self.arg2.eval(row, schema)
+
+    def __str__(self):
+        return "({0} | {1})".format(self.arg1, self.arg2)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -25,9 +25,18 @@ class Minus(NullSafeBinaryOperation):
     def __str__(self):
         return "({0} - {1})".format(self.arg1, self.arg2)
 
+
 class Time(NullSafeBinaryOperation):
     def unsafe_operation(self, value1, value2):
         return value1 * value2
 
     def __str__(self):
         return "({0} * {1})".format(self.arg1, self.arg2)
+
+
+class Divide(NullSafeBinaryOperation):
+    def unsafe_operation(self, value1, value2):
+        return value1 / value2 if value2 != 0 else None
+
+    def __str__(self):
+        return "({0} / {1})".format(self.arg1, self.arg2)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -88,3 +88,10 @@ class LessThanOrEqual(TypeSafeBinaryOperation):
 
     def __str__(self):
         return "({0} <= {1})".format(self.arg1, self.arg2)
+
+class GreaterThan(TypeSafeBinaryOperation):
+    def unsafe_operation(self, value_1, value_2):
+        return value_1 > value_2
+
+    def __str__(self):
+        return "({0} > {1})".format(self.arg1, self.arg2)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -113,3 +113,10 @@ class And(TypeSafeBinaryOperation):
     def __str__(self):
         return "({0} AND {1})".format(self.arg1, self.arg2)
 
+
+class Or(TypeSafeBinaryOperation):
+    def unsafe_operation(self, value_1, value_2):
+        return value_1 or value_2
+
+    def __str__(self):
+        return "({0} OR {1})".format(self.arg1, self.arg2)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -144,3 +144,17 @@ class BitwiseOr(Expression):
 
     def __str__(self):
         return "({0} | {1})".format(self.arg1, self.arg2)
+
+
+class BitwiseAnd(Expression):
+    def __init__(self, arg1, arg2):
+        super(BitwiseAnd, self).__init__(arg1, arg2)
+        self.arg1 = arg1
+        self.arg2 = arg2
+
+    def eval(self, row, schema):
+        return self.arg1.eval(row, schema) & self.arg2.eval(row, schema)
+
+    def __str__(self):
+        return "({0} & {1})".format(self.arg1, self.arg2)
+

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -323,3 +323,28 @@ class Substring(Expression):
 
     def __str__(self):
         return "substring({0}, {1}, {2})".format(self.expr, self.start, self.length)
+
+
+class Alias(Expression):
+    def __init__(self, expr, alias):
+        super(Alias, self).__init__(expr, alias)
+        self.expr = expr
+        self.alias = alias
+
+    @property
+    def may_output_multiple_cols(self):
+        return self.expr.may_output_multiple_cols
+
+    @property
+    def may_output_multiple_rows(self):
+        return self.expr.may_output_multiple_rows
+
+    @property
+    def is_an_aggregation(self):
+        return self.expr.is_an_aggregation
+
+    def eval(self, row, schema):
+        return self.expr.eval(row, schema)
+
+    def __str__(self):
+        return self.alias

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -104,3 +104,12 @@ class GreaterThanOrEqual(TypeSafeBinaryOperation):
 
     def __str__(self):
         return "({0} >= {1})".format(self.arg1, self.arg2)
+
+
+class And(TypeSafeBinaryOperation):
+    def unsafe_operation(self, value_1, value_2):
+        return value_1 and value_2
+
+    def __str__(self):
+        return "({0} AND {1})".format(self.arg1, self.arg2)
+

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -246,3 +246,16 @@ class StartsWith(Expression):
 
     def __str__(self):
         return "startswith({0}, {1})".format(self.arg1, self.substr)
+
+
+class EndsWith(Expression):
+    def __init__(self, arg1, substr):
+        super(EndsWith, self).__init__(arg1, substr)
+        self.arg1 = arg1
+        self.substr = substr
+
+    def eval(self, row, schema):
+        return str(self.arg1.eval(row, schema)).endswith(self.substr)
+
+    def __str__(self):
+        return "endswith({0}, {1})".format(self.arg1, self.substr)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -24,3 +24,10 @@ class Minus(NullSafeBinaryOperation):
 
     def __str__(self):
         return "({0} - {1})".format(self.arg1, self.arg2)
+
+class Time(NullSafeBinaryOperation):
+    def unsafe_operation(self, value1, value2):
+        return value1 * value2
+
+    def __str__(self):
+        return "({0} * {1})".format(self.arg1, self.arg2)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -57,3 +57,11 @@ class Pow(NullSafeBinaryOperation):
     def __str__(self):
         return "POWER({0}, {1})".format(self.arg1, self.arg2)
 
+
+class Pmod(NullSafeBinaryOperation):
+    def unsafe_operation(self, value1, value2):
+        return value1 % value2
+
+    def __str__(self):
+        return "pmod({0} % {1})".format(self.arg1, self.arg2)
+

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -80,3 +80,11 @@ class LessThan(TypeSafeBinaryOperation):
 
     def __str__(self):
         return "({0} < {1})".format(self.arg1, self.arg2)
+
+
+class LessThanOrEqual(TypeSafeBinaryOperation):
+    def unsafe_operation(self, value_1, value_2):
+        return value_1 <= value_2
+
+    def __str__(self):
+        return "({0} <= {1})".format(self.arg1, self.arg2)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -2,6 +2,7 @@ from pysparkling import Row
 from pysparkling.sql.casts import get_caster
 from pysparkling.sql.expressions.expressions import Expression, UnaryExpression, \
     NullSafeBinaryOperation, TypeSafeBinaryOperation
+from pysparkling.sql.types import StructType
 
 
 class Negate(UnaryExpression):
@@ -284,6 +285,14 @@ class IsNotNull(UnaryExpression):
 
     def __str__(self):
         return "({0} IS NOT NULL)".format(self.column)
+
+
+class IsNull(UnaryExpression):
+    def eval(self, row, schema):
+        return self.column.eval(row, schema) is None
+
+    def __str__(self):
+        return "({0} IS NULL)".format(self.column)
 
 
 class Cast(Expression):

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -89,9 +89,18 @@ class LessThanOrEqual(TypeSafeBinaryOperation):
     def __str__(self):
         return "({0} <= {1})".format(self.arg1, self.arg2)
 
+
 class GreaterThan(TypeSafeBinaryOperation):
     def unsafe_operation(self, value_1, value_2):
         return value_1 > value_2
 
     def __str__(self):
         return "({0} > {1})".format(self.arg1, self.arg2)
+
+
+class GreaterThanOrEqual(TypeSafeBinaryOperation):
+    def unsafe_operation(self, value_1, value_2):
+        return value_1 >= value_2
+
+    def __str__(self):
+        return "({0} >= {1})".format(self.arg1, self.arg2)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -16,3 +16,11 @@ class Add(NullSafeBinaryOperation):
 
     def __str__(self):
         return "({0} + {1})".format(self.arg1, self.arg2)
+
+
+class Minus(NullSafeBinaryOperation):
+    def unsafe_operation(self, value1, value2):
+        return value1 - value2
+
+    def __str__(self):
+        return "({0} - {1})".format(self.arg1, self.arg2)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -348,3 +348,38 @@ class Alias(Expression):
 
     def __str__(self):
         return self.alias
+
+
+__all__ = [
+    "Negate",
+    "Add",
+    "Minus",
+    "Time",
+    "Divide",
+    "Mod",
+    "Pow",
+    "Pmod",
+    "Equal",
+    "LessThan",
+    "LessThanOrEqual",
+    "GreaterThan",
+    "GreaterThanOrEqual",
+    "And",
+    "Or",
+    "Invert",
+    "BitwiseOr",
+    "BitwiseAnd",
+    "BitwiseXor",
+    "BitwiseNot",
+    "EqNullSafe",
+    "GetField",
+    "Contains",
+    "StartsWith",
+    "EndsWith",
+    "IsIn",
+    "IsNotNull",
+    "Cast",
+    "Substring",
+    "IsNull",
+    "Alias"
+]

--- a/pysparkling/sql/expressions/orders.py
+++ b/pysparkling/sql/expressions/orders.py
@@ -29,3 +29,7 @@ class DescNullsFirst(SortOrder):
 
 class DescNullsLast(SortOrder):
     sort_order = "DESC NULLS LAST"
+
+
+Asc = AscNullsFirst
+Desc = DescNullsLast

--- a/pysparkling/sql/expressions/orders.py
+++ b/pysparkling/sql/expressions/orders.py
@@ -1,0 +1,15 @@
+from pysparkling.sql.expressions.expressions import Expression
+
+
+class SortOrder(Expression):
+    sort_order = None
+
+    def __init__(self, column):
+        super(SortOrder, self).__init__(column)
+        self.column = column
+
+    def eval(self, row, schema):
+        return self.column.eval(row, schema)
+
+    def __str__(self):
+        return "{0} {1}".format(self.column, self.sort_order)

--- a/pysparkling/sql/expressions/orders.py
+++ b/pysparkling/sql/expressions/orders.py
@@ -13,3 +13,19 @@ class SortOrder(Expression):
 
     def __str__(self):
         return "{0} {1}".format(self.column, self.sort_order)
+
+
+class AscNullsFirst(SortOrder):
+    sort_order = "ASC NULLS FIRST"
+
+
+class AscNullsLast(SortOrder):
+    sort_order = "ASC NULLS LAST"
+
+
+class DescNullsFirst(SortOrder):
+    sort_order = "DESCNULLS FIRST"
+
+
+class DescNullsLast(SortOrder):
+    sort_order = "DESC NULLS LAST"


### PR DESCRIPTION
File modified in this PR:
- new: [pysparkling/sql/expressions/orders.py ](https://github.com/svenkreiss/pysparkling/pull/111/files#diff-bac904c0d78e7d4b977f11ee96de671e)

This PR introduces order-related `Expression`s. For instance, `df.sort(df.age.desc())` will sort `df` by `age` in descending order.

The actual sorting logic is implemented in `DataFrame.sort()`

This PR is on top of #110 