### PR TITLE
Feat/read write

### DIFF
--- a/pysparkling/sql/dataframe.py
+++ b/pysparkling/sql/dataframe.py
@@ -61,6 +61,18 @@ class DataFrame(object):
         self._jdf.createOrReplaceGlobalTempView(name)
 
     @property
+    def write(self):
+        # Top level import would cause cyclic dependencies
+        # pylint: disable=import-outside-toplevel
+        from pysparkling.sql.readwriter import DataFrameWriter
+
+        return DataFrameWriter(self)
+
+    @property
+    def writeStream(self):
+        raise NotImplementedError("Pysparkling does not support yet writing to stream")
+
+    @property
     def schema(self):
         return self._jdf.unbound_schema
 

--- a/pysparkling/sql/internal_utils/options.py
+++ b/pysparkling/sql/internal_utils/options.py
@@ -1,0 +1,63 @@
+class Options(dict):
+    """
+    A case insensitive dict, which can be initialized from multiple dicts
+    and whose values can be access through attr syntax
+
+    It also stores "false" and "true" strings as Boolean
+
+    e.g.:
+
+    >>> default_options = dict(sep=",", samplingRatio=None)
+    >>> requested_options = dict(Sep="|")
+    >>> o=Options({"format": "json", "lineSep": ","}, Format="csv")
+    >>> o.format, o.linesep
+    ('csv', ',')
+    >>> o.UndefinedSetting
+    Traceback (most recent call last):
+    ...
+    KeyError: 'undefinedsetting'
+    """
+
+    def __init__(self, *args, **kwargs):
+        d = {
+            key.lower(): value
+            for arg in args
+            if arg is not None
+            for key, value in arg.items()
+        }
+        d.update({
+            key.lower(): value
+            for key, value in kwargs.items()
+        })
+        super(Options, self).__init__(d)
+
+    def setdefault(self, k, default=None):
+        return super(Options, self).setdefault(k.lower(), default)
+
+    @staticmethod
+    def fromkeys(seq, value=None):
+        return Options({k.lower(): value for k in seq})
+
+    def __getitem__(self, k):
+        return super(Options, self).__getitem__(k.lower())
+
+    def __setitem__(self, k, v):
+        if isinstance(v, str) and v.lower() in ("true", "false"):
+            v = (v.lower() == "true")
+        super(Options, self).__setitem__(k.lower(), v)
+
+    def __delitem__(self, k):
+        super(Options, self).__delitem__(k.lower())
+
+    def get(self, k, *args, **kwargs):
+        return super(Options, self).get(k.lower(), *args, **kwargs)
+
+    def __contains__(self, o):
+        if not isinstance(o, str):
+            return False
+        return super(Options, self).__contains__(o.lower())
+
+    def __getattr__(self, item):
+        if not item.startswith("_"):
+            return self[item.lower()]
+        return getattr(super(Options, self), item)

--- a/pysparkling/sql/internal_utils/readers/__init__.py
+++ b/pysparkling/sql/internal_utils/readers/__init__.py
@@ -1,0 +1,1 @@
+from pysparkling.sql.internal_utils.readers.common import InternalReader

--- a/pysparkling/sql/internal_utils/readers/common.py
+++ b/pysparkling/sql/internal_utils/readers/common.py
@@ -1,0 +1,33 @@
+from pysparkling.sql.internal_utils.readers.csvreader import CSVReader
+from pysparkling.sql.internal_utils.readers.jsonreader import JSONReader
+from pysparkling.sql.internal_utils.readers.textreader import TextReader
+from pysparkling.sql.internal_utils.readwrite import OptionUtils, to_option_stored_value
+from pysparkling.sql.types import StructType
+
+
+class InternalReader(OptionUtils):
+    def schema(self, schema):
+        if not isinstance(schema, StructType):
+            raise NotImplementedError("Pysparkling currently only supports StructType for schemas")
+        self._schema = schema
+
+    def option(self, key, value):
+        self._options[key.lower()] = to_option_stored_value(value)
+
+    def __init__(self, spark):
+        """
+
+        :type spark: pysparkling.sql.session.SparkSession
+        """
+        self._spark = spark
+        self._options = {}
+        self._schema = None
+
+    def csv(self, paths):
+        return CSVReader(self._spark, paths, self._schema, self._options).read()
+
+    def json(self, paths):
+        return JSONReader(self._spark, paths, self._schema, self._options).read()
+
+    def text(self, paths):
+        return TextReader(self._spark, paths, self._schema, self._options).read()

--- a/pysparkling/sql/internal_utils/readers/csvreader.py
+++ b/pysparkling/sql/internal_utils/readers/csvreader.py
@@ -1,0 +1,114 @@
+import itertools
+from functools import partial
+
+from pysparkling.fileio import TextFile
+from pysparkling.sql.casts import get_caster
+from pysparkling.sql.internal_utils.options import Options
+from pysparkling.sql.internal_utils.readers.utils import resolve_partitions, \
+    guess_schema_from_strings
+from pysparkling.sql.internals import DataFrameInternal
+from pysparkling.sql.schema_utils import infer_schema_from_rdd
+from pysparkling.sql.types import StructType, StringType, StructField, create_row
+
+
+class CSVReader(object):
+    default_options = dict(
+        lineSep=None,
+        encoding="utf-8",
+        sep=",",
+        inferSchema=False,
+        header=False
+    )
+
+    def __init__(self, spark, paths, schema, options):
+        self.spark = spark
+        self.paths = paths
+        self.schema = schema
+        self.options = Options(self.default_options, options)
+
+    def read(self):
+        sc = self.spark._sc
+        paths = self.paths
+
+        partitions, partition_schema = resolve_partitions(paths)
+
+        rdd_filenames = sc.parallelize(sorted(partitions.keys()), len(partitions))
+        rdd = rdd_filenames.flatMap(partial(
+            parse_csv_file,
+            partitions,
+            partition_schema,
+            self.schema,
+            self.options
+        ))
+
+        if self.schema is not None:
+            schema = self.schema
+        elif self.options.inferSchema:
+            fields = rdd.take(1)[0].__fields__
+            schema = guess_schema_from_strings(fields, rdd.collect(), options=self.options)
+        else:
+            schema = infer_schema_from_rdd(rdd)
+
+        schema_with_string = StructType(fields=[
+            StructField(field.name, StringType()) for field in schema.fields
+        ])
+
+        if partition_schema:
+            partitions_fields = partition_schema.fields
+            full_schema = StructType(schema.fields[:-len(partitions_fields)] + partitions_fields)
+        else:
+            full_schema = schema
+
+        cast_row = get_caster(
+            from_type=schema_with_string, to_type=full_schema, options=self.options
+        )
+        casted_rdd = rdd.map(cast_row)
+        casted_rdd._name = paths
+
+        return DataFrameInternal(
+            sc,
+            casted_rdd,
+            schema=full_schema
+        )
+
+
+def parse_csv_file(partitions, partition_schema, schema, options, file_name):
+    f_content = TextFile(file_name).load(encoding=options.encoding).read()
+    records = (f_content.split(options.lineSep)
+               if options.lineSep is not None
+               else f_content.splitlines())
+    if options.header == "true":
+        header = records[0].split(options.sep)
+        records = records[1:]
+    else:
+        header = None
+
+    null_value = ""
+    rows = []
+    for record in records:
+        row = csv_record_to_row(
+            record, options, schema, header, null_value, partition_schema, partitions[file_name]
+        )
+        row.set_input_file_name(file_name)
+        rows.append(row)
+
+    return rows
+
+
+def csv_record_to_row(record, options, schema=None, header=None,
+                      null_value=None, partition_schema=None, partition=None):
+    record_values = [val if val != null_value else None for val in record.split(options.sep)]
+    if schema is not None:
+        field_names = [f.name for f in schema.fields]
+    elif header is not None:
+        field_names = header
+    else:
+        field_names = ["_c{0}".format(i) for i, field in enumerate(record_values)]
+    partition_field_names = [
+        f.name for f in partition_schema.fields
+    ] if partition_schema else []
+    row = create_row(
+        itertools.chain(field_names, partition_field_names),
+        itertools.chain(record_values, partition or [])
+    )
+    return row

--- a/pysparkling/sql/internal_utils/readers/jsonreader.py
+++ b/pysparkling/sql/internal_utils/readers/jsonreader.py
@@ -1,0 +1,135 @@
+import itertools
+import json
+from functools import partial
+
+from pysparkling.sql.casts import get_struct_caster
+from pysparkling.sql.internal_utils.options import Options
+from pysparkling.sql.internal_utils.readers.utils import resolve_partitions, get_records
+from pysparkling.sql.internals import DataFrameInternal
+from pysparkling.sql.schema_utils import infer_schema_from_rdd
+from pysparkling.sql.types import StructType, create_row, row_from_keyed_values
+
+
+class JSONReader(object):
+    default_options = dict(
+        primitivesAsString=False,
+        prefersDecimal=False,
+        allowComments=False,
+        allowUnquotedFieldNames=False,
+        allowSingleQuotes=True,
+        allowNumericLeadingZero=False,
+        allowBackslashEscapingAnyCharacter=False,
+        mode="PERMISSIVE",
+        columnNameOfCorruptRecord="",
+        dateFormat="yyyy-MM-dd",
+        timestampFormat="yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+        multiLine=False,
+        allowUnquotedControlChars=False,
+        encoding=None,
+        lineSep=None,
+        samplingRatio=1.0,
+        dropFieldIfAllNull=False,
+        locale="en-US",
+    )
+
+    def __init__(self, spark, paths, schema, options):
+        self.spark = spark
+        self.paths = paths
+        self.schema = schema
+        self.options = Options(self.default_options, options)
+
+    def read(self):
+        sc = self.spark._sc
+        paths = self.paths
+
+        partitions, partition_schema = resolve_partitions(paths)
+
+        rdd_filenames = sc.parallelize(sorted(partitions.keys()), len(partitions))
+        rdd = rdd_filenames.flatMap(partial(
+            parse_json_file,
+            partitions,
+            partition_schema,
+            self.schema,
+            self.options
+        ))
+
+        inferred_schema = infer_schema_from_rdd(rdd)
+
+        schema = self.schema if self.schema is not None else inferred_schema
+        schema_fields = {
+            field.name: field
+            for field in schema.fields
+        }
+
+        # Field order is defined by fields in the record, not by the given schema
+        # Field type is defined by the given schema or inferred
+        full_schema = StructType(
+            fields=[
+                schema_fields.get(field.name, field)
+                for field in inferred_schema.fields
+            ]
+        )
+
+        cast_row = get_struct_caster(inferred_schema, full_schema, options=self.options)
+        casted_rdd = rdd.map(cast_row)
+        casted_rdd._name = paths
+
+        return DataFrameInternal(
+            sc,
+            casted_rdd,
+            schema=full_schema
+        )
+
+
+def parse_json_file(partitions, partition_schema, schema, options, file_name):
+    records = get_records(file_name, options.linesep, options.encoding)
+    rows = []
+    for record in records:
+        partition = partitions[file_name]
+        row = parse_record(record, schema, partition, partition_schema, options)
+        row.set_input_file_name(file_name)
+        rows.append(row)
+    return rows
+
+
+def parse_record(record, schema, partition, partition_schema, options):
+    raw_record_value = json.loads(record, encoding=options.encoding)
+    if not isinstance(raw_record_value, dict):
+        raise NotImplementedError(
+            "Top level items should be JSON objects (dicts), got {0} with {1}".format(
+                type(raw_record_value),
+                raw_record_value
+            )
+        )
+    record_value = decode_record(raw_record_value)
+    if schema is not None:
+        record_fields = record_value.__fields__
+        available_names = tuple(partition_schema.names) + record_fields
+        field_names = [name for name in record_fields if name in schema.names] + [
+            f.name for f in schema.fields if f.name not in available_names
+        ]
+    else:
+        field_names = list(record_value.__fields__)
+    record_values = [
+        record_value[field_name] if field_name in record_value.__fields__ else None
+        for field_name in field_names
+    ]
+    partition_field_names = [f.name for f in partition_schema.fields] if partition_schema else []
+    # pylint: disable=W0511
+    # todo: handle nested rows
+    row = create_row(
+        itertools.chain(field_names, partition_field_names),
+        itertools.chain(record_values, partition)
+    )
+    return row
+
+
+def decode_record(item):
+    if isinstance(item, list):
+        return [decode_record(e) for e in item]
+    if isinstance(item, dict):
+        return row_from_keyed_values(
+            (key, decode_record(value))
+            for key, value in item.items()
+        )
+    return item

--- a/pysparkling/sql/internal_utils/readers/textreader.py
+++ b/pysparkling/sql/internal_utils/readers/textreader.py
@@ -1,0 +1,79 @@
+import itertools
+from functools import partial
+
+from pysparkling.fileio import TextFile
+from pysparkling.sql.internal_utils.options import Options
+from pysparkling.sql.internal_utils.readers.utils import resolve_partitions
+from pysparkling.sql.internals import DataFrameInternal
+from pysparkling.sql.types import StructType, create_row, StructField, StringType
+
+
+class TextReader(object):
+    default_options = dict(
+        lineSep=None,
+        encoding="utf-8",
+        sep=",",
+        inferSchema=False,
+        header=False
+    )
+
+    def __init__(self, spark, paths, schema, options):
+        self.spark = spark
+        self.paths = paths
+        self.schema = schema or StructType([StructField("value", StringType())])
+        self.options = Options(self.default_options, options)
+
+    def read(self):
+        sc = self.spark._sc
+        paths = self.paths
+
+        partitions, partition_schema = resolve_partitions(paths)
+
+        rdd_filenames = sc.parallelize(sorted(partitions.keys()), len(partitions))
+        rdd = rdd_filenames.flatMap(partial(
+            parse_text_file,
+            partitions,
+            partition_schema,
+            self.schema,
+            self.options
+        ))
+
+        if partition_schema:
+            partitions_fields = partition_schema.fields
+            full_schema = StructType(self.schema.fields + partitions_fields)
+        else:
+            full_schema = self.schema
+
+        rdd._name = paths
+
+        return DataFrameInternal(
+            sc,
+            rdd,
+            schema=full_schema
+        )
+
+
+def parse_text_file(partitions, partition_schema, schema, options, file_name):
+    f_content = TextFile(file_name).load(encoding=options.encoding).read()
+    records = (f_content.split(options.lineSep)
+               if options.lineSep is not None
+               else f_content.splitlines())
+
+    rows = []
+    for record in records:
+        row = text_record_to_row(record, options, schema, partition_schema, partitions[file_name])
+        row.set_input_file_name(file_name)
+        rows.append(row)
+
+    return rows
+
+
+def text_record_to_row(record, options, schema, partition_schema, partition):
+    partition_field_names = [
+        f.name for f in partition_schema.fields
+    ] if partition_schema else []
+    row = create_row(
+        itertools.chain([schema.fields[0].name], partition_field_names),
+        itertools.chain([record], partition or [])
+    )
+    return row

--- a/pysparkling/sql/internal_utils/readers/utils.py
+++ b/pysparkling/sql/internal_utils/readers/utils.py
@@ -1,0 +1,7 @@
+from pysparkling.fileio import TextFile
+
+
+def get_records(f_name, linesep, encoding):
+    f_content = TextFile(f_name).load(encoding=encoding).read()
+    records = f_content.split(linesep) if linesep is not None else f_content.splitlines()
+    return records

--- a/pysparkling/sql/internal_utils/readers/utils.py
+++ b/pysparkling/sql/internal_utils/readers/utils.py
@@ -1,4 +1,37 @@
 from pysparkling.fileio import TextFile
+from pysparkling.sql.casts import get_caster
+from pysparkling.sql.types import IntegerType, LongType, DecimalType, \
+    DoubleType, TimestampType, StringType
+from pysparkling.sql.utils import AnalysisException
+
+
+def guess_type_from_values_as_string(values, options):
+    # Reproduces inferences available in Spark
+    # PartitioningUtils.inferPartitionColumnValue()
+    # located in org.apache.spark.sql.execution.datasources
+    tested_types = (
+        IntegerType(),
+        LongType(),
+        DecimalType(),
+        DoubleType(),
+        TimestampType(),
+        StringType()
+    )
+    string_type = StringType()
+    for tested_type in tested_types:
+        type_caster = get_caster(from_type=string_type, to_type=tested_type, options=options)
+        try:
+            for value in values:
+                casted_value = type_caster(value)
+                if casted_value is None and value not in ("null", None):
+                    raise ValueError
+            return tested_type
+        except ValueError:
+            pass
+    # Should never happen
+    raise AnalysisException(
+        "Unable to find a matching type for some fields, even StringType did not work"
+    )
 
 
 def get_records(f_name, linesep, encoding):

--- a/pysparkling/sql/internal_utils/readers/utils.py
+++ b/pysparkling/sql/internal_utils/readers/utils.py
@@ -1,8 +1,27 @@
 from pysparkling.fileio import TextFile
 from pysparkling.sql.casts import get_caster
-from pysparkling.sql.types import IntegerType, LongType, DecimalType, \
+from pysparkling.sql.types import StructType, StructField, IntegerType, LongType, DecimalType, \
     DoubleType, TimestampType, StringType
 from pysparkling.sql.utils import AnalysisException
+
+
+def guess_schema_from_strings(schema_fields, data, options):
+    field_values = [
+        (field, [row[field] for row in data])
+        for field in schema_fields
+    ]
+
+    field_types_and_values = [
+        (field, guess_type_from_values_as_string(values, options))
+        for field, values in field_values
+    ]
+
+    schema = StructType(fields=[
+        StructField(field, field_type)
+        for field, field_type in field_types_and_values
+    ])
+
+    return schema
 
 
 def guess_type_from_values_as_string(values, options):

--- a/pysparkling/sql/internal_utils/readwrite.py
+++ b/pysparkling/sql/internal_utils/readwrite.py
@@ -1,0 +1,30 @@
+from pysparkling.sql.utils import IllegalArgumentException
+
+
+def to_option_stored_value(value):
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+class OptionUtils(object):
+    def _set_opts(self, schema=None, **options):
+        """
+        Set named options (filter out those the value is None)
+        """
+        if schema is not None:
+            self.schema(schema)
+        for k, v in options.items():
+            if v is not None:
+                self.option(k, v)
+
+    def option(self, key, value):
+        raise NotImplementedError
+
+    def schema(self, schema):
+        # By default OptionUtils subclass do not support schema
+        raise IllegalArgumentException(
+            "schema is not a valid argument for {0}".format(self.__class__)
+        )

--- a/pysparkling/sql/internal_utils/writers.py
+++ b/pysparkling/sql/internal_utils/writers.py
@@ -1,3 +1,7 @@
+from pysparkling import Row
+from pysparkling.sql.expressions.aggregate.aggregations import Aggregation
+from pysparkling.sql.expressions.mappers import StarOperator
+from pysparkling.sql.functions import col
 from pysparkling.sql.internal_utils.readwrite import to_option_stored_value
 
 
@@ -49,3 +53,49 @@ class InternalWriter(object):
             self._sort_col_names
         ).save()
 
+
+class WriteInFolder(Aggregation):
+    """
+    This use the computation engine of pysparkling to write the values in a folder.
+
+    It's behaviour is similar to a collect_list except that items are written
+    in a folder instead of being returned:
+
+    Its evaluation only return the number of items written while writing them
+    using the writer given in the constructor, more specifically its write method.
+
+    Pre-formatting is done as defined by writer.preformat during the merge phase.
+
+    """
+
+    def __init__(self, writer):
+        super(WriteInFolder, self).__init__()
+        self.column = col(StarOperator())
+        self.writer = writer
+        self.ref_value = None
+        self.items = []
+
+    def merge(self, row, schema):
+        row_value = self.column.eval(row, schema)
+        if self.ref_value is None:
+            ref_value = Row(*row_value)
+            ref_value.__fields__ = schema.names
+            self.ref_value = ref_value
+        self.items.append(
+            self.writer.preformat(row_value, schema)
+        )
+
+    def mergeStats(self, other, schema):
+        self.items += other.items
+        if self.ref_value is None:
+            self.ref_value = other.ref_value
+
+    def eval(self, row, schema):
+        return self.writer.write(
+            self.items,
+            self.ref_value,
+            self.pre_evaluation_schema
+        )
+
+    def __str__(self):
+        return "write_in_folder({0})".format(self.column)

--- a/pysparkling/sql/internal_utils/writers.py
+++ b/pysparkling/sql/internal_utils/writers.py
@@ -1,8 +1,16 @@
+import csv
+import os
+import shutil
+
 from pysparkling import Row
+from pysparkling.sql.casts import cast_to_string
 from pysparkling.sql.expressions.aggregate.aggregations import Aggregation
 from pysparkling.sql.expressions.mappers import StarOperator
 from pysparkling.sql.functions import col
+from pysparkling.sql.internal_utils.options import Options
 from pysparkling.sql.internal_utils.readwrite import to_option_stored_value
+from pysparkling.sql.utils import AnalysisException
+from pysparkling.utils import portable_hash
 
 
 class InternalWriter(object):
@@ -99,3 +107,206 @@ class WriteInFolder(Aggregation):
 
     def __str__(self):
         return "write_in_folder({0})".format(self.column)
+
+
+class DataWriter(object):
+    default_options = dict(
+        dateFormat="yyyy-MM-dd",
+        timestampFormat="yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+    )
+
+    def __init__(self, df, mode, options, partitioning_col_names, num_buckets,
+                 bucket_col_names, sort_col_names):
+        """
+
+        :param df: pysparkling.sql.DataFrame
+        :param mode: str
+        :param options: Dict[str, Optional[str]]
+        :param partitioning_col_names: Optional[List[str]]
+        :param num_buckets: Optional[int]
+        :param bucket_col_names: Optional[List[str]]
+        :param sort_col_names: Optional[List[str]]
+        """
+        self.mode = mode
+        self.options = Options(self.default_options, options)
+        self.partitioning_col_names = partitioning_col_names if partitioning_col_names else []
+        self.num_buckets = num_buckets
+        self.bucket_col_names = bucket_col_names if partitioning_col_names else []
+        self.sort_col_names = sort_col_names if partitioning_col_names else []
+        if self.partitioning_col_names:
+            self.apply_on_aggregated_data = df.groupBy(*self.partitioning_col_names).agg
+        else:
+            self.apply_on_aggregated_data = df.select
+
+    @property
+    def path(self):
+        return self.options["path"].rstrip("/")
+
+    @property
+    def compression(self):
+        return None
+
+    @property
+    def encoding(self):
+        return None
+
+    def save(self):
+        output_path = self.path
+        mode = self.mode
+        if os.path.exists(output_path):
+            if mode == "ignore":
+                return
+            if mode in ("error", "errorifexists"):
+                raise AnalysisException("path {0} already exists.;".format(output_path))
+            if mode == "overwrite":
+                shutil.rmtree(output_path)
+                os.makedirs(output_path)
+        else:
+            os.makedirs(output_path)
+
+        self.apply_on_aggregated_data(col(WriteInFolder(writer=self))).collect()
+
+        success_path = os.path.join(output_path, "_SUCCESS")
+
+        with open(success_path, "w"):
+            pass
+
+    def preformat(self, row, schema):
+        raise NotImplementedError
+
+    def write(self, items, ref_value, schema):
+        """
+        Write a list of rows (items) which have a given schema
+
+        Returns the number of rows written
+        """
+        raise NotImplementedError
+
+
+class CSVWriter(DataWriter):
+    def check_options(self):
+        unsupported_options = {
+            "compression",
+            "encoding",
+            "chartoescapequoteescaping",
+            "escape",
+            "escapequotes"
+        }
+        options_requested_but_not_supported = set(self.options) & unsupported_options
+        if options_requested_but_not_supported:
+            raise NotImplementedError(
+                "Pysparkling does not support yet the following options: {0}".format(
+                    options_requested_but_not_supported
+                )
+            )
+
+    def preformat_cell(self, value, field):
+        if value is None:
+            value = self.nullValue
+        else:
+            value = cast_to_string(
+                value,
+                from_type=field.dataType,
+                options=self.options
+            )
+        if self.ignoreLeadingWhiteSpace:
+            value = value.rstrip()
+        if self.ignoreTrailingWhiteSpace:
+            value = value.lstrip()
+        if value == "":
+            return self.emptyValue
+        return value
+
+    def preformat(self, row, schema):
+        return tuple(
+            self.preformat_cell(value, field)
+            for value, field in zip(row, schema.fields)
+        )
+
+    @property
+    def sep(self):
+        return self.options.get("sep", ",")
+
+    @property
+    def quote(self):
+        quote = self.options.get("quote", '"')
+        return "\u0000" if quote == "" else quote
+
+    @property
+    def escape(self):
+        return self.options.get("escape", "\\")
+
+    @property
+    def header(self):
+        return self.options.get("header", "false") != "false"
+
+    @property
+    def nullValue(self):
+        return self.options.get("nullvalue", "")
+
+    @property
+    def escapeQuotes(self):
+        return self.options.get("escapequotes", "true") != "false"
+
+    @property
+    def quoteAll(self):
+        return self.options.get("quoteall", "false") != "false"
+
+    @property
+    def ignoreLeadingWhiteSpace(self):
+        return self.options.get("ignoreleadingwhiteSpace", 'false') != "false"
+
+    @property
+    def ignoreTrailingWhiteSpace(self):
+        return self.options.get("ignoretrailingwhiteSpace", 'false') != "false"
+
+    @property
+    def charToEscapeQuoteEscaping(self):
+        return None
+
+    @property
+    def emptyValue(self):
+        return self.options.get("emptyvalue", '""')
+
+    @property
+    def lineSep(self):
+        return self.options.get("linesep", "\n")
+
+    def write(self, items, ref_value, schema):
+        self.check_options()
+        output_path = self.path
+
+        if not items:
+            return 0
+
+        partition_parts = [
+            "{0}={1}".format(col_name, ref_value[col_name])
+            for col_name in self.partitioning_col_names
+        ]
+        file_path = "/".join(
+            [output_path]
+            + partition_parts
+            + ["part-00000-{0}.csv".format(portable_hash(ref_value))]
+        )
+
+        # pylint: disable=W0511
+        # todo: Add support of:
+        #  - all files systems (not only local)
+        #  - compression
+        #  - encoding
+        #  - charToEscapeQuoteEscaping
+        #  - escape
+        #  - escapeQuotes
+
+        with open(file_path, "w") as f:
+            writer = csv.writer(
+                f,
+                delimiter=self.sep,
+                quotechar=self.quote,
+                quoting=csv.QUOTE_ALL if self.quoteAll else csv.QUOTE_MINIMAL,
+                lineterminator=self.lineSep
+            )
+            if self.header:
+                writer.writerow(schema.names)
+            writer.writerows(items)
+        return len(items)

--- a/pysparkling/sql/internal_utils/writers.py
+++ b/pysparkling/sql/internal_utils/writers.py
@@ -1,0 +1,51 @@
+from pysparkling.sql.internal_utils.readwrite import to_option_stored_value
+
+
+class InternalWriter(object):
+    def __init__(self, df):
+        self._df = df
+        self._source = "parquet"
+        self._mode = "errorifexists"
+        self._options = {}
+        self._partitioning_col_names = None
+        self._num_buckets = None
+        self._bucket_col_names = None
+        self._sort_col_names = None
+
+    def option(self, k, v):
+        self._options[k.lower()] = to_option_stored_value(v)
+        return self
+
+    def mode(self, mode):
+        self._mode = mode
+        return self
+
+    def format(self, source):
+        self._source = source
+        return self
+
+    def partitionBy(self, partitioning_col_names):
+        self._partitioning_col_names = partitioning_col_names
+        return self
+
+    def bucketBy(self, num_buckets, *bucket_cols):
+        self._num_buckets = num_buckets
+        self._bucket_col_names = bucket_cols
+        return self
+
+    def sortBy(self, sort_cols):
+        self._sort_col_names = sort_cols
+        return self
+
+    def save(self, writer_class, path=None):
+        self.option("path", path)
+        return writer_class(
+            self._df,
+            self._mode,
+            self._options,
+            self._partitioning_col_names,
+            self._num_buckets,
+            self._bucket_col_names,
+            self._sort_col_names
+        ).save()
+

--- a/pysparkling/sql/readwriter.py
+++ b/pysparkling/sql/readwriter.py
@@ -1,0 +1,93 @@
+from pysparkling import RDD
+from pysparkling.sql.dataframe import DataFrame
+from pysparkling.sql.internal_utils.readers import InternalReader
+from pysparkling.sql.internal_utils.readwrite import OptionUtils
+
+
+class DataFrameReader(OptionUtils):
+    def option(self, key, value):
+        self._jreader.option(key, value)
+        return self
+
+    def schema(self, schema):
+        self._jreader.schema(schema)
+        return self
+
+    def __init__(self, spark):
+        """
+
+        :type spark: pysparkling.sql.session.SparkSession
+        """
+        self._jreader = InternalReader(spark)
+        self._spark = spark
+
+    def _df(self, jdf):
+        return DataFrame(jdf, self._spark)
+
+    # pylint: disable=R0914
+    def csv(self, path, schema=None, sep=None, encoding=None, quote=None, escape=None,
+            comment=None, header=None, inferSchema=None, ignoreLeadingWhiteSpace=None,
+            ignoreTrailingWhiteSpace=None, nullValue=None, nanValue=None, positiveInf=None,
+            negativeInf=None, dateFormat=None, timestampFormat=None, maxColumns=None,
+            maxCharsPerColumn=None, maxMalformedLogPerPartition=None, mode=None,
+            columnNameOfCorruptRecord=None, multiLine=None, charToEscapeQuoteEscaping=None,
+            samplingRatio=None, enforceSchema=None, emptyValue=None, locale=None, lineSep=None):
+        self._set_opts(
+            schema=schema, sep=sep, encoding=encoding, quote=quote, escape=escape, comment=comment,
+            header=header, inferSchema=inferSchema, ignoreLeadingWhiteSpace=ignoreLeadingWhiteSpace,
+            ignoreTrailingWhiteSpace=ignoreTrailingWhiteSpace, nullValue=nullValue,
+            nanValue=nanValue, positiveInf=positiveInf, negativeInf=negativeInf,
+            dateFormat=dateFormat, timestampFormat=timestampFormat, maxColumns=maxColumns,
+            maxCharsPerColumn=maxCharsPerColumn,
+            maxMalformedLogPerPartition=maxMalformedLogPerPartition, mode=mode,
+            columnNameOfCorruptRecord=columnNameOfCorruptRecord, multiLine=multiLine,
+            charToEscapeQuoteEscaping=charToEscapeQuoteEscaping, samplingRatio=samplingRatio,
+            enforceSchema=enforceSchema, emptyValue=emptyValue, locale=locale, lineSep=lineSep
+        )
+        if isinstance(path, str):
+            path = [path]
+        if isinstance(path, list):
+            return self._df(self._jreader.csv(path))
+        if isinstance(path, RDD):
+            return self._df(self._jreader.csv(path.collect()))
+        raise TypeError("path can be only string, list or RDD")
+
+    # pylint: disable=R0914
+    def json(self, path, schema=None, primitivesAsString=None, prefersDecimal=None,
+             allowComments=None, allowUnquotedFieldNames=None, allowSingleQuotes=None,
+             allowNumericLeadingZero=None, allowBackslashEscapingAnyCharacter=None,
+             mode=None, columnNameOfCorruptRecord=None, dateFormat=None, timestampFormat=None,
+             multiLine=None, allowUnquotedControlChars=None, lineSep=None, samplingRatio=None,
+             dropFieldIfAllNull=None, encoding=None, locale=None):
+        self._set_opts(
+            schema=schema, primitivesAsString=primitivesAsString, prefersDecimal=prefersDecimal,
+            allowComments=allowComments, allowUnquotedFieldNames=allowUnquotedFieldNames,
+            allowSingleQuotes=allowSingleQuotes, allowNumericLeadingZero=allowNumericLeadingZero,
+            allowBackslashEscapingAnyCharacter=allowBackslashEscapingAnyCharacter,
+            mode=mode, columnNameOfCorruptRecord=columnNameOfCorruptRecord, dateFormat=dateFormat,
+            timestampFormat=timestampFormat, multiLine=multiLine,
+            allowUnquotedControlChars=allowUnquotedControlChars, lineSep=lineSep,
+            samplingRatio=samplingRatio, dropFieldIfAllNull=dropFieldIfAllNull, encoding=encoding,
+            locale=locale)
+        if isinstance(path, str):
+            path = [path]
+        if isinstance(path, list):
+            return self._df(self._jreader.json(path))
+        if isinstance(path, RDD):
+            return self._df(self._jreader.json(path.collect()))
+        raise TypeError("path can be only string, list or RDD")
+
+    def text(self, paths, wholetext=False, lineSep=None,
+             pathGlobFilter=None, recursiveFileLookup=None):
+        self._set_opts(wholetext=wholetext,
+                       lineSep=lineSep,
+                       pathGlobFilter=pathGlobFilter,
+                       recursiveFileLookup=recursiveFileLookup)
+        if isinstance(paths, str):
+            paths = [paths]
+        if isinstance(paths, list):
+            return self._df(self._jreader.text(paths))
+        if isinstance(paths, RDD):
+            return self._df(self._jreader.text(paths.collect()))
+        raise TypeError("paths can be only string, list or RDD")
+

--- a/pysparkling/sql/readwriter.py
+++ b/pysparkling/sql/readwriter.py
@@ -2,6 +2,14 @@ from pysparkling import RDD
 from pysparkling.sql.dataframe import DataFrame
 from pysparkling.sql.internal_utils.readers import InternalReader
 from pysparkling.sql.internal_utils.readwrite import OptionUtils
+from pysparkling.sql.internal_utils.writers import CSVWriter, JSONWriter, InternalWriter
+from pysparkling.sql.utils import IllegalArgumentException
+
+WRITE_MODES = ("overwrite", "append", "ignore", "error", "errorifexists")
+DATA_WRITERS = dict(
+    csv=CSVWriter,
+    json=JSONWriter,
+)
 
 
 class DataFrameReader(OptionUtils):
@@ -91,3 +99,127 @@ class DataFrameReader(OptionUtils):
             return self._df(self._jreader.text(paths.collect()))
         raise TypeError("paths can be only string, list or RDD")
 
+
+class DataFrameWriter(OptionUtils):
+    def __init__(self, df):
+        self._df = df
+        self._spark = df.sql_ctx
+        self._jwrite = InternalWriter(self._df)
+
+    def mode(self, saveMode):
+        if saveMode is None:
+            return self
+        if saveMode not in WRITE_MODES:
+            raise IllegalArgumentException(
+                "Unknown save mode: {0}. Accepted save modes are {1}.".format(
+                    saveMode,
+                    "', '".join(WRITE_MODES)
+                )
+            )
+        self._jwrite = self._jwrite.mode(saveMode)
+        return self
+
+    def format(self, source):
+        self._jwrite = self._jwrite.format(source)
+        return self
+
+    def option(self, key, value):
+        self._jwrite.option(key, value)
+        return self
+
+    def options(self, **options):
+        for k in options:
+            self._jwrite.option(k, options[k])
+        return self
+
+    def partitionBy(self, *cols):
+        if len(cols) == 1 and isinstance(cols[0], (list, tuple)):
+            cols = cols[0]
+        self._jwrite = self._jwrite.partitionBy(cols)
+        return self
+
+    def bucketBy(self, numBuckets, col, *cols):
+        if not isinstance(numBuckets, int):
+            raise TypeError("numBuckets should be an int, got {0}.".format(type(numBuckets)))
+
+        if isinstance(col, (list, tuple)):
+            if cols:
+                raise ValueError("col is a {0} but cols are not empty".format(type(col)))
+
+            cols = col
+        else:
+            cols = [col] + list(cols)
+
+        if not all(isinstance(c, str) for c in cols):
+            raise TypeError("all names should be `str`")
+
+        self._jwrite = self._jwrite.bucketBy(numBuckets, *cols)
+        return self
+
+    def sortBy(self, col, *cols):
+        if isinstance(col, (list, tuple)):
+            if cols:
+                raise ValueError("col is a {0} but cols are not empty".format(type(col)))
+
+            col, cols = col[0], col[1:]
+
+        if not all(isinstance(c, str) for c in cols) or not isinstance(col, str):
+            raise TypeError("all names should be `str`")
+
+        self._jwrite = self._jwrite.sortBy(col, *cols)
+        return self
+
+    # noinspection PyShadowingBuiltins
+    # pylint: disable=W0622
+    def save(self, path=None, format=None, mode=None, partitionBy=None, **options):
+        self.mode(mode).options(**options)
+        if partitionBy is not None:
+            self.partitionBy(partitionBy)
+        if format is not None:
+            self.format(format)
+        writer_class = DATA_WRITERS[self._jwrite._source]
+        if path is None:
+            self._jwrite.save(writer_class)
+        else:
+            self._jwrite.save(writer_class, path)
+
+    def json(self, path, mode=None, compression=None, dateFormat=None, timestampFormat=None,
+             lineSep=None, encoding=None):
+        self.mode(mode)
+        self._set_opts(
+            compression=compression, dateFormat=dateFormat, timestampFormat=timestampFormat,
+            lineSep=lineSep, encoding=encoding)
+        self.format("json").save(path)
+
+    # pylint: disable=R0914
+    def csv(self, path, mode=None, compression=None, sep=None, quote=None, escape=None,
+            header=None, nullValue=None, escapeQuotes=None, quoteAll=None, dateFormat=None,
+            timestampFormat=None, ignoreLeadingWhiteSpace=None, ignoreTrailingWhiteSpace=None,
+            charToEscapeQuoteEscaping=None, encoding=None, emptyValue=None, lineSep=None):
+        self.mode(mode)
+        self._set_opts(compression=compression, sep=sep, quote=quote, escape=escape, header=header,
+                       nullValue=nullValue, escapeQuotes=escapeQuotes, quoteAll=quoteAll,
+                       dateFormat=dateFormat, timestampFormat=timestampFormat,
+                       ignoreLeadingWhiteSpace=ignoreLeadingWhiteSpace,
+                       ignoreTrailingWhiteSpace=ignoreTrailingWhiteSpace,
+                       charToEscapeQuoteEscaping=charToEscapeQuoteEscaping,
+                       encoding=encoding, emptyValue=emptyValue, lineSep=lineSep)
+        self.format("csv").save(path)
+
+    def insertInto(self, tableName=None):
+        raise NotImplementedError("Pysparkling does not implement write to table yet")
+
+    def saveAsTable(self, name):
+        raise NotImplementedError("Pysparkling does not implement write to table yet")
+
+    def parquet(self, path):
+        raise NotImplementedError("Pysparkling does not implement write to parquet yet")
+
+    def text(self, path):
+        raise NotImplementedError("Pysparkling does not implement write to text yet")
+
+    def orc(self, path):
+        raise NotImplementedError("Pysparkling does not implement write to ORC")
+
+    def jdbc(self, path):
+        raise NotImplementedError("Pysparkling does not implement write to JDBC")

--- a/pysparkling/sql/session.py
+++ b/pysparkling/sql/session.py
@@ -10,6 +10,7 @@ from pysparkling.context import Context
 from pysparkling.sql.conf import RuntimeConfig
 from pysparkling.sql.internals import DataFrameInternal
 from pysparkling.sql.dataframe import DataFrame
+from pysparkling.sql.readwriter import DataFrameReader
 from pysparkling.sql.schema_utils import infer_schema_from_list
 from pysparkling.sql.utils import require_minimum_pandas_version
 
@@ -307,6 +308,4 @@ class SparkSession(object):
 
     @property
     def read(self):
-        raise NotImplementedError(
-            "This method implementation requires DataFrameReader which are not yet merged"
-        )
+        return DataFrameReader(self)

--- a/pysparkling/sql/types.py
+++ b/pysparkling/sql/types.py
@@ -1588,6 +1588,14 @@ class Row(tuple):
         self._metadata["grouping"] = grouping
         return self
 
+    def set_input_file_name(self, input_file_name):
+        # This method is specific to Pysparkling and should not be used by
+        # user of the library who wants compatibility with PySpark
+        if self._metadata is None:
+            self.set_metadata({})
+        self._metadata["input_file_name"] = input_file_name
+        return self
+
     def set_metadata(self, metadata):
         # This method is specific to Pysparkling and should not be used by
         # user of the library who wants compatibility with PySpark


### PR DESCRIPTION
This PR introduces 3 DataFrame readers: text, csv and json, as well as 2 DataFrame Writers: csv and json

This enable for instance:
```python
df = spark.read.json("data.json")
# operations on df
result.write.json("result")
```
